### PR TITLE
Jenkins multibranch pipeline support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,39 @@
+#!groovy
+node {
+   def mvnHome
+   stage('Preparation') {
+   
+      // Get code from GitHub repositories
+
+      // this will check if there is a branch with the same name as the current branch and use that for the checkout, but if there is no
+      // branch with the same name it will fall back to the master branch
+      dir('gemoc-studio') {
+         def gemocstudioScm = resolveScm source: [$class: 'GitSCMSource', credentialsId: '', id: '_', remote: 'https://github.com/eclipse/gemoc-studio.git', traits: [[$class: 'BranchDiscoveryTrait']]], targets: [BRANCH_NAME, 'master']
+         checkout gemocstudioScm
+      }
+      dir('gemoc-studio-modeldebugging') {
+         def gemocstudiomodeldebuggingScm = resolveScm source: [$class: 'GitSCMSource', credentialsId: '', id: '_', remote: 'https://github.com/eclipse/gemoc-studio-modeldebugging.git', traits: [[$class: 'BranchDiscoveryTrait']]], targets: [BRANCH_NAME, 'master']
+         checkout gemocstudiomodeldebuggingScm
+      }
+      sh "ls"
+      // Get the Maven tool.
+      // ** NOTE: This 'apache-maven-latest' Maven tool must be configured in the global configuration.           
+      mvnHome = tool 'apache-maven-latest'
+   }
+   stage('Build') {
+      // Run the maven build without any test            
+      dir ('gemoc-studio/dev_support/full_compilation') {
+         sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
+      }      
+   }
+   stage('Tests') {
+      // Run the maven build without  the tests but off line (this is supposed to be already downloaded)            
+      dir ('gemoc-studio/dev_support/full_compilation') {
+         sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
+      }      
+   }
+   stage('Results') {
+      junit '**/target/surefire-reports/TEST-*.xml'
+      archiveArtifacts '**/target/products/*.zip'
+   }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
    stage('Tests') {
       // Run the maven build without  the tests but off line (this is supposed to be already downloaded)            
       dir ('gemoc-studio/dev_support/full_compilation') {
-         wrap([$class: 'Xvfb']) {
+         wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
             // sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
             sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --errors -P ignore_CI_repositories,!use_CI_repositories"
          }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,13 +23,15 @@ node {
    stage('Build') {
       // Run the maven build without any test            
       dir ('gemoc-studio/dev_support/full_compilation') {
-         sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
+         // sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
+         sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --errors -P ignore_CI_repositories,!use_CI_repositories"
       }      
    }
    stage('Tests') {
       // Run the maven build without  the tests but off line (this is supposed to be already downloaded)            
       dir ('gemoc-studio/dev_support/full_compilation') {
-         sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
+         // sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
+         sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --errors -P ignore_CI_repositories,!use_CI_repositories"
       }      
    }
    stage('Results') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,46 +1,49 @@
 #!groovy
 node {
-   def mvnHome
-   stage('Preparation') {
-   
-      // Get code from GitHub repositories
-
-      // this will check if there is a branch with the same name as the current branch (ie. the branch containing this Jenkinsfile) and use that for the checkout, but if there is no
-      // branch with the same name it will fall back to the master branch
-      dir('gemoc-studio') {
-         def gemocstudioScm = resolveScm source: [$class: 'GitSCMSource', credentialsId: '', id: '_', remote: 'https://github.com/eclipse/gemoc-studio.git', traits: [[$class: 'BranchDiscoveryTrait']]], targets: [BRANCH_NAME, 'master']
-         checkout gemocstudioScm
-      }
-      dir('gemoc-studio-modeldebugging') {
-         def gemocstudiomodeldebuggingScm = resolveScm source: [$class: 'GitSCMSource', credentialsId: '', id: '_', remote: 'https://github.com/eclipse/gemoc-studio-modeldebugging.git', traits: [[$class: 'BranchDiscoveryTrait']]], targets: [BRANCH_NAME, 'master']
-         checkout gemocstudiomodeldebuggingScm
-      }
-      echo 'Content of the workspace'
-      sh "ls"
-      // Get the Maven tool.
-      // ** NOTE: This 'apache-maven-latest' Maven tool must be configured in the global configuration.
-      // in order to find existing tools and their name, use the snippet generator available in the target jenkins instance (ie.  "Pipeline Syntax" link on the job)         
-      mvnHome = tool 'apache-maven-latest'
+   catchError {
+	   def mvnHome
+	   stage('Preparation') {
+	   
+	      // Get code from GitHub repositories
+	
+	      // this will check if there is a branch with the same name as the current branch (ie. the branch containing this Jenkinsfile) and use that for the checkout, but if there is no
+	      // branch with the same name it will fall back to the master branch
+	      dir('gemoc-studio') {
+	         def gemocstudioScm = resolveScm source: [$class: 'GitSCMSource', credentialsId: '', id: '_', remote: 'https://github.com/eclipse/gemoc-studio.git', traits: [[$class: 'BranchDiscoveryTrait']]], targets: [BRANCH_NAME, 'master']
+	         checkout gemocstudioScm
+	      }
+	      dir('gemoc-studio-modeldebugging') {
+	         def gemocstudiomodeldebuggingScm = resolveScm source: [$class: 'GitSCMSource', credentialsId: '', id: '_', remote: 'https://github.com/eclipse/gemoc-studio-modeldebugging.git', traits: [[$class: 'BranchDiscoveryTrait']]], targets: [BRANCH_NAME, 'master']
+	         checkout gemocstudiomodeldebuggingScm
+	      }
+	      echo 'Content of the workspace'
+	      sh "ls"
+	      // Get the Maven tool.
+	      // ** NOTE: This 'apache-maven-latest' Maven tool must be configured in the global configuration.
+	      // in order to find existing tools and their name, use the snippet generator available in the target jenkins instance (ie.  "Pipeline Syntax" link on the job)         
+	      mvnHome = tool 'apache-maven-latest'
+	   }
+	   stage('Build') {
+	      // Run the maven build without any test            
+	      dir ('gemoc-studio/dev_support/full_compilation') {
+	         // sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
+	         sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --errors -P ignore_CI_repositories,!use_CI_repositories"
+	      }      
+	   }
+	   stage('Tests') {
+	      // Run the maven build with the tests (integration tests need Xvnc)
+	      // run offline (this is supposed to be already downloaded)
+	      dir ('gemoc-studio/dev_support/full_compilation') {
+	         wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+	            // sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
+	            sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+	         }
+	      }      
+	   }
+	   stage('Results') {
+	      junit '**/target/surefire-reports/TEST-*.xml'
+	      archiveArtifacts '**/target/products/*.zip,**/gemoc-studio/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/target/repository/**'
+	   }
    }
-   stage('Build') {
-      // Run the maven build without any test            
-      dir ('gemoc-studio/dev_support/full_compilation') {
-         // sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
-         sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --errors -P ignore_CI_repositories,!use_CI_repositories"
-      }      
-   }
-   stage('Tests') {
-      // Run the maven build with the tests (integration tests need Xvnc)
-      // run offline (this is supposed to be already downloaded)
-      dir ('gemoc-studio/dev_support/full_compilation') {
-         wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
-            // sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
-            sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --errors -P ignore_CI_repositories,!use_CI_repositories"
-         }
-      }      
-   }
-   stage('Results') {
-      junit '**/target/surefire-reports/TEST-*.xml'
-      archiveArtifacts '**/target/products/*.zip,**/gemoc-studio/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/target/repository/**'
-   }
+   step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: '', sendToIndividuals: true])
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,8 +30,10 @@ node {
    stage('Tests') {
       // Run the maven build without  the tests but off line (this is supposed to be already downloaded)            
       dir ('gemoc-studio/dev_support/full_compilation') {
-         // sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
-         sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+         wrap([$class: 'Xvfb']) {
+            // sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
+            sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+         }
       }      
    }
    stage('Results') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,10 @@ node {
 	   stage('Build and verify') {
 	      // Run the maven build without any test            
 	      dir ('gemoc-studio/dev_support/full_compilation') {
-	         // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
-	         sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+	          wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+	              // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+	              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+	          }
 	      }      
 	   }	   
 	   stage('Deployment') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,24 +23,14 @@ node {
 	      // in order to find existing tools and their name, use the snippet generator available in the target jenkins instance (ie.  "Pipeline Syntax" link on the job)         
 	      mvnHome = tool 'apache-maven-latest'
 	   }
-	   stage('Build') {
+	   stage('Build and verify') {
 	      // Run the maven build without any test            
 	      dir ('gemoc-studio/dev_support/full_compilation') {
-	         // sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
-	         sh "'${mvnHome}/bin/mvn' -DskipTests=true clean package --errors -P ignore_CI_repositories,!use_CI_repositories"
+	         // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+	         sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
 	      }      
-	   }
-	   stage('Tests') {
-	      // Run the maven build with the tests (integration tests need Xvnc)
-	      // run offline (this is supposed to be already downloaded)
-	      dir ('gemoc-studio/dev_support/full_compilation') {
-	         wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
-	            // sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --debug --errors -P ignore_CI_repositories,!use_CI_repositories"
-	            sh "'${mvnHome}/bin/mvn' -o -Dmaven.test.failure.ignore verify --errors -P ignore_CI_repositories,!use_CI_repositories"
-	         }
-	      }      
-	   }
-	   stage('Results') {
+	   }	   
+	   stage('Deployment') {
 	      junit '**/target/surefire-reports/TEST-*.xml'
 	      archiveArtifacts '**/target/products/*.zip,**/gemoc-studio/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/target/repository/**'
 	   }

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <repository>
             <id>melange</id>
             <layout>p2</layout>
-            <url>http://melange-lang.org/updatesite/</url>
+            <url>http://melange.inria.fr/updatesite/releases/0.2.0/neon/</url>
         </repository>
         <repository>
             <id>Sirius</id>


### PR DESCRIPTION
I propose to use this Jenkinsfile to drive the ci in a "multibranch pipeline job". (see the result in https://ci.eclipse.org/gemoc/job/gemoc-studio/ )

It enables the possibility to build studio on several branches (automatically detected) and be able to test them before accepting them.
It uses _resolveScm_ in order to use branches with the same name or fall back on master branch. Ie. you can have some change in 2 repo, they will be considered together if they are in branches with the same name.

One of the drawback of pipeline is that the workspace browser is a bit less easy to find in the CI UI. You need to select a branch, then the build, then the pipeline step, the node, then the workspace :disappointed_relieved:  (see [where did workspace go in pipeline](https://www.selikoff.net/2016/07/10/workspace-jenkins-pipelines/)) However, this is not blocking.

Some point are still unclear for me (that could be improved later if this doesn't work out of the box):
- what about the automatic trigger ? do we need to copy this jenkins file in all our repo in order to get a notification of a change and trigger the build on the appropriate branch.
- I've split the build and test in 2 stages, this is nice for presentation, however, I'm not sure this is the most efficient because maven+tycho doesn't seem to be efficient when running the phases in separate commands (even if `mvn verify` is run with `--offline` option). We may decide to keep a separate job for fast delivery on the master branch that will not run the tests.
