### PR TITLE
Studio variant identification

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node {
 		      dir ('gemoc-studio/dev_support/full_compilation') {
 		          wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
 		              // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
-		              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore -Dstudio.variant=${studioVariant} -Dbranch.variant=${BRANCH_VARIANT} clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+		              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore \"-Dstudio.variant=${studioVariant}\" -Dbranch.variant=${BRANCH_VARIANT} clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
 		          }
 		      }      
 	      }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
 		      dir ('gemoc-studio/dev_support/full_compilation') {
 		          wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
 		              // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
-		              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+		              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore -Dstudio.variant=${STUDIO_VARIANT} -Dbranch.variant=${BRANCH_VARIANT} clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
 		          }
 		      }      
 	      }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,13 +24,19 @@ node {
 	      mvnHome = tool 'apache-maven-latest'
 	   }
 	   stage('Build and verify') {
+	      def studioVariant
+	      if(  "${JENKINS_URL}".equals("https://hudson.eclipse.org/gemoc/")){
+	      	studioVariant = "Official build"
+	      } else {
+	      	studioVariant = "${JENKINS_URL}"
+	      }
 	      // Run the maven build with tests  
-	      withEnv(["STUDIO_VARIANT=${JENKINS_URL}","BRANCH_VARIANT=${BRANCH_NAME}"]){ 
+	      withEnv(["STUDIO_VARIANT=${studioVariant}","BRANCH_VARIANT=${BRANCH_NAME}"]){ 
 	          sh 'printenv'         
 		      dir ('gemoc-studio/dev_support/full_compilation') {
 		          wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
 		              // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
-		              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore -Dstudio.variant=${STUDIO_VARIANT} -Dbranch.variant=${BRANCH_VARIANT} clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+		              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore -Dstudio.variant=${studioVariant} -Dbranch.variant=${BRANCH_VARIANT} clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
 		          }
 		      }      
 	      }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,8 @@ node {
 	   }
 	   stage('Build and verify') {
 	      // Run the maven build with tests  
-	      withEnv(["studio.variant=${env.JENKINS_URL}","branch.variant=${env.BRANCH_NAME}"]){          
+	      withEnv(["STUDIO_VARIANT=${JENKINS_URL}","BRANCH_VARIANT=${BRANCH_NAME}"]){ 
+	          sh 'printenv'         
 		      dir ('gemoc-studio/dev_support/full_compilation') {
 		          wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
 		              // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ node {
 	   stage('Build and verify') {
 	      // Run the maven build with tests  
 	      withEnv(["studio.variant=${env.JENKINS_URL}","branch.variant=${env.BRANCH_NAME}"]){          
-		      dir (gemoc-studio/dev_support/full_compilation') {
+		      dir ('gemoc-studio/dev_support/full_compilation') {
 		          wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
 		              // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
 		              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node {
 	   }
 	   stage('Build and verify') {
 	      def studioVariant
-	      if(  "${JENKINS_URL}".equals("https://hudson.eclipse.org/gemoc/")){
+	      if(  env.JENKINS_URL.contains("https://hudson.eclipse.org/gemoc/")){
 	      	studioVariant = "Official build"
 	      } else {
 	      	studioVariant = "${JENKINS_URL}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,13 +24,15 @@ node {
 	      mvnHome = tool 'apache-maven-latest'
 	   }
 	   stage('Build and verify') {
-	      // Run the maven build without any test            
-	      dir ('gemoc-studio/dev_support/full_compilation') {
-	          wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
-	              // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
-	              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
-	          }
-	      }      
+	      // Run the maven build with tests  
+	      withEnv(["studio.variant=${env.JENKINS_URL}","branch.variant=${env.BRANCH_NAME}"]){          
+		      dir (gemoc-studio/dev_support/full_compilation') {
+		          wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+		              // sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+		              sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean verify --errors -P ignore_CI_repositories,!use_CI_repositories"
+		          }
+		      }      
+	      }
 	   }	   
 	   stage('Deployment') {
 	      junit '**/target/surefire-reports/TEST-*.xml'

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystemManager.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystemManager.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gemoc.commons.eclipse.messagingsystem.api;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.gemoc.commons.messagingsystem.api.impl.StdioSimpleMessagingSystem;
@@ -64,7 +63,7 @@ public class MessagingSystemManager {
 				result = (MessagingSystem) confElements[i].createExecutableExtension(MESSAGINGSYSTEM_EXTENSION_POINT_CONTRIB_MESSAGINGSYSTEM_ATT);
 				result.initialize(baseMessageGroup, userFriendlyName);
 				if(result != null)	break;
-			} catch (CoreException e) {;
+			} catch (Throwable e) {;
 			}
 		}
 		if (result == null){

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/plugin.properties
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/plugin.properties
@@ -11,11 +11,12 @@
 productBlurb=Gemoc Studio\n\
 \n\
 Version: {0}\n\
+Variant: {2} - {3} branch\n\
 Build id: {1}\n\
 \n\
 A Language Workbench for Heterogeneous Modeling and Analysis of Complex Software-Intensive Systems\n\
-(c) Copyright Gemoc 2012, 2016.  All rights reserved.\n\
-Visit http://www.gemoc.org\n
+(c) Copyright Gemoc 2012, 2017.  All rights reserved.\n\
+Visit https://projects.eclipse.org/projects/modeling.gemoc and http://www.gemoc.org\ n
 
 product.name=Gemoc Studio
 

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
@@ -14,13 +14,9 @@
 
 	<properties>
 		<eclipse.version.name>Neon.3</eclipse.version.name>
-		<!-- override these values using system properties specific to the CI (see jenkinsfile for CI configuration)-->
-		<!-- note: jenkinsfile doesn't deal very well with dot in the property name, so use this uppercase version instead -->
-		<STUDIO_VARIANT>Local build </STUDIO_VARIANT>
-		<BRANCH_VARIANT>Unknown branch</BRANCH_VARIANT>
-		<!-- copy in a more readable variable for use in the rest of the pom -->
-		<studio.variant>${STUDIO_VARIANT}</studio.variant>
-		<branch.variant>${BRANCH_VARIANT}</branch.variant>
+		<!-- override these values using -D option on the maven command line on the CI (see jenkinsfile for CI configuration)-->		
+		<studio.variant>Local build</studio.variant>
+		<branch.variant>Unknown</branch.variant>
 	</properties>
 
 	<artifactId>org.eclipse.gemoc.gemoc_studio.branding</artifactId>

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
@@ -15,8 +15,12 @@
 	<properties>
 		<eclipse.version.name>Neon.3</eclipse.version.name>
 		<!-- override these values using system properties specific to the CI (see jenkinsfile for CI configuration)-->
-		<studio.variant>Local build </studio.variant>
-		<branch.variant>Unknown branch</branch.variant>
+		<!-- note: jenkinsfile doesn't deal very well with dot in the property name, so use this uppercase version instead -->
+		<STUDIO_VARIANT>Local build </STUDIO_VARIANT>
+		<BRANCH_VARIANT>Unknown branch</BRANCH_VARIANT>
+		<!-- copy in a more readable variable for use in the rest of the pom -->
+		<studio.variant>${STUDIO_VARIANT}</studio.variant>
+		<branch.variant>${BRANCH_VARIANT}</branch.variant>
 	</properties>
 
 	<artifactId>org.eclipse.gemoc.gemoc_studio.branding</artifactId>

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
@@ -87,12 +87,12 @@
 			                            <fontName>SansSerif</fontName>
 			                            <fontStyle>italic,bold</fontStyle>
 			                            <fontSize>12</fontSize>
-			                            <position>right-15,bottom-25</position>
+			                            <position>right-15,bottom-45</position>
 			                        </drawText>
 			                        <!-- Eclipse Logo 64 -->
 			                        <drawImage>
                             			<imageName>eclipse</imageName>
-                            			<position>right-20,bottom-45</position>
+                            			<position>right-20,bottom-65</position>
                         			</drawImage>
 			                        <!-- Eclipse version -->
 	                            	<drawText>
@@ -101,25 +101,16 @@
 			                            <fontName>SansSerif</fontName>
 			                            <fontStyle>italic,bold</fontStyle>
 			                            <fontSize>16</fontSize>
-			                            <position>right-15,bottom-45</position>
+			                            <position>right-15,bottom-65</position>
 			                        </drawText>
 			                        <!-- Studio variant -->
 	                            	<drawText>
-			                            <text>${studio.variant}</text>
+			                            <text>${studio.variant} - ${branch.variant} branch</text>
 			                            <textColor>#909090</textColor>
 			                            <fontName>SansSerif</fontName>
 			                            <fontStyle>italic,bold</fontStyle>
 			                            <fontSize>12</fontSize>
-			                            <position>right-15,bottom-125</position>
-			                        </drawText>
-			                        <!-- Branch variant -->
-	                            	<drawText>
-			                            <text>${branch.variant}</text>
-			                            <textColor>#909090</textColor>
-			                            <fontName>SansSerif</fontName>
-			                            <fontStyle>italic,bold</fontStyle>
-			                            <fontSize>12</fontSize>
-			                            <position>right-15,bottom-105</position>
+			                            <position>right-15,bottom-30</position>
 			                        </drawText>
 	                            </draw>
 	                        </canvas>

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
@@ -14,6 +14,9 @@
 
 	<properties>
 		<eclipse.version.name>Neon.3</eclipse.version.name>
+		<!-- override these values using system properties specific to the CI (see jenkinsfile for CI configuration)-->
+		<studio.variant>Local build </studio.variant>
+		<branch.variant>Unknown branch</branch.variant>
 	</properties>
 
 	<artifactId>org.eclipse.gemoc.gemoc_studio.branding</artifactId>
@@ -99,6 +102,24 @@
 			                            <fontStyle>italic,bold</fontStyle>
 			                            <fontSize>16</fontSize>
 			                            <position>right-15,bottom-45</position>
+			                        </drawText>
+			                        <!-- Studio variant -->
+	                            	<drawText>
+			                            <text>${studio.variant}</text>
+			                            <textColor>#909090</textColor>
+			                            <fontName>SansSerif</fontName>
+			                            <fontStyle>italic,bold</fontStyle>
+			                            <fontSize>12</fontSize>
+			                            <position>right-15,bottom-125</position>
+			                        </drawText>
+			                        <!-- Branch variant -->
+	                            	<drawText>
+			                            <text>${branch.variant}</text>
+			                            <textColor>#909090</textColor>
+			                            <fontName>SansSerif</fontName>
+			                            <fontStyle>italic,bold</fontStyle>
+			                            <fontSize>12</fontSize>
+			                            <position>right-15,bottom-105</position>
 			                        </drawText>
 	                            </draw>
 	                        </canvas>

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/filtered-resources/about.mappings
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/filtered-resources/about.mappings
@@ -1,2 +1,4 @@
 0=${project.version}
 1=${buildNumber}
+2=${studio.variant}
+3=${branch.variant}


### PR DESCRIPTION
This PR adds description strings in the splash screen and in the about box in order to help identify the running studio. 
Ie. It indicates if this is an official version from eclipse CI on its master branch or on another branch or from an external CI (for example the old CI used before the code was pushed to Eclipse foundation)