### PR TITLE
fixes the setValue of StringOption which failed to correctly display

### DIFF
--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.pde/src/org/eclipse/gemoc/commons/eclipse/pde/wizards/pages/pde/ui/templates/OptionTemplateSection.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.pde/src/org/eclipse/gemoc/commons/eclipse/pde/wizards/pages/pde/ui/templates/OptionTemplateSection.java
@@ -310,6 +310,34 @@ public abstract class OptionTemplateSection extends BaseOptionTemplateSection {
 			page.setErrorMessage(message);
 		}
 	}
+	
+	/**
+	 * Locates the page that this option is presented in and flags that the
+	 * option has an error. The flagging is done by
+	 * setting the page incomplete and setting the error message with the 
+	 * provided message prefixed by the option's message label.
+	 * 
+	 * @param option
+	 *            the option that is required and currently not set
+	 * @param msg
+	 *            the message indicating the error for the given option
+	 */
+	protected void flagErrorOnOption(TemplateOption option, String msg) {
+		WizardPage page = null;
+		for (int i = 0; i < pages.size(); i++) {
+			TemplatePage tpage = pages.get(i);
+			ArrayList<TemplateOption> list = tpage.options;
+			if (list.contains(option)) {
+				page = tpage.page;
+				break;
+			}
+		}
+		if (page != null) {
+			page.setPageComplete(false);
+			String message = option.getMessageLabel()+": "+msg;
+			page.setErrorMessage(message);
+		}
+	}
 
 	/**
 	 * Resets the current page state by clearing the error message and making

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.pde/src/org/eclipse/gemoc/commons/eclipse/pde/wizards/pages/pde/ui/templates/StringOption.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.pde/src/org/eclipse/gemoc/commons/eclipse/pde/wizards/pages/pde/ui/templates/StringOption.java
@@ -116,7 +116,7 @@ public class StringOption extends TemplateOption {
 	 */
 	public void setValue(Object value) {
 		super.setValue(value);
-		if (text != null && !getText().equals(value)) {
+		if (text != null && !text.getText().equals(value)) {
 			ignoreListener = true;
 			String textValue = getText();
 			text.setText(textValue != null ? textValue : ""); //$NON-NLS-1$


### PR DESCRIPTION
This PR brings several improvement to the GEMOC project wizard templates.

in the main repo, it adds a fix about initial values not shown in the templates


this PR can be tested by looking at the CI https://ci.eclipse.org/gemoc/job/gemoc-studio/job/improve-gemoc-project-template-wizard/