### PR TITLE
Improve messagingsystem usability

### DIFF
--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystem.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystem.java
@@ -24,7 +24,7 @@ import org.eclipse.gemoc.commons.messagingsystem.api.reference.Reference;
  */
 public abstract class MessagingSystem {
 	public static enum Kind {
-		UserINFO, UserWARNING, UserERROR, DevDEBUG, DevINFO, DevWARNING, DevERROR 
+		UserINFO, UserImportantINFO, UserWARNING, UserERROR, DevDEBUG, DevINFO, DevWARNING, DevERROR 
 	}
 	
 	public static int UNKNOWN_NBWORKUNIT = -1;
@@ -91,6 +91,14 @@ public abstract class MessagingSystem {
 	 */
 	public void info(String message, String messageGroup){
 		log(MessagingSystem.Kind.UserINFO, message, messageGroup);
+	}
+	/**
+	 * convenient operation for quicker call
+	 * Equivalent to
+	 * log(MessagingSystem.Kind.UserImportantINFO, message, messageGroup)
+	 */
+	public void important(String message, String messageGroup){
+		log(MessagingSystem.Kind.UserImportantINFO, message, messageGroup);
 	}
 	/**
 	 * convenient operation for quicker call

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystem.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/api/MessagingSystem.java
@@ -95,10 +95,10 @@ public abstract class MessagingSystem {
 	/**
 	 * convenient operation for quicker call
 	 * Equivalent to
-	 * log(MessagingSystem.Kind.UserWARNING, message, messageGroup, senderTrace)
+	 * log(MessagingSystem.Kind.DevWARNING, message, messageGroup, senderTrace)
 	 */
 	public void warn(String message, String messageGroup, Throwable senderTrace){
-		log(MessagingSystem.Kind.UserWARNING, message, messageGroup, senderTrace);
+		log(MessagingSystem.Kind.DevWARNING, message, messageGroup, senderTrace);
 	}
 	/**
 	 * convenient operation for quicker call
@@ -111,10 +111,10 @@ public abstract class MessagingSystem {
 	/**
 	 * convenient operation for quicker call
 	 * Equivalent to
-	 * log(MessagingSystem.Kind.UserERROR, message, messageGroup, senderTrace)
+	 * log(MessagingSystem.Kind.DevERROR, message, messageGroup, senderTrace)
 	 */
 	public void error(String message, String messageGroup, Throwable senderTrace){
-		log(MessagingSystem.Kind.UserERROR, message, messageGroup, senderTrace);
+		log(MessagingSystem.Kind.DevERROR, message, messageGroup, senderTrace);
 	}
 	/**
 	 * convenient operation for quicker call

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/messagingsystem/api/impl/StdioSimpleMessagingSystem.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/src/main/java/org/eclipse/gemoc/commons/messagingsystem/api/impl/StdioSimpleMessagingSystem.java
@@ -109,6 +109,8 @@ public class StdioSimpleMessagingSystem extends MessagingSystem {
 		
 		case UserINFO :
 			return "INFO";
+		case UserImportantINFO :
+			return "IMPORTANT";
 		case UserWARNING :
 			return "WARNING";
 		case UserERROR :
@@ -136,7 +138,7 @@ public class StdioSimpleMessagingSystem extends MessagingSystem {
 		// return first caller which isn't getCallerString or log
 		for(StackTraceElement stackTraceElement : stackTraceElements){
 			if(! (	stackTraceElement.getMethodName().contains("log") || 
-					stackTraceElement.getClassName().contains("org.kermeta.utils.systemservices.api"))){
+					stackTraceElement.getClassName().contains("org.eclipse.gemoc.commons.eclipse.messagingsystem.api"))){
 				
 				return stackTraceElement.toString();
 			}

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/ConsoleLogLevel.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/ConsoleLogLevel.java
@@ -18,8 +18,9 @@ public class ConsoleLogLevel{
 	public static final int 	DEV_WARNING = 3;
 	public static final int 	DEV_ERROR = 4;
 	public static final int 	USER_INFO= 8;
-	public static final int 	USER_WARNING = 9;
-	public static final int 	USER_ERROR = 10;
+	public static final int 	USER_IMPORTANTINFO= 9;
+	public static final int 	USER_WARNING = 10;
+	public static final int 	USER_ERROR = 11;
 	
 	public static boolean isLevelEnoughToLog(Integer requiredLevel, Integer allowedLevel){
 		return requiredLevel>=allowedLevel;
@@ -37,6 +38,8 @@ public class ConsoleLogLevel{
 			return "DEV_ERROR";
 		case USER_INFO :
 			return "USER_INFO";
+		case USER_IMPORTANTINFO :
+			return "USER_IMPORTANT";
 		case USER_WARNING :
 			return "USER_WARNING";
 		case USER_ERROR :
@@ -51,6 +54,7 @@ public class ConsoleLogLevel{
 		if(s.equals("DEV_WARNING")) return DEV_WARNING;
 		if(s.equals("DEV_ERROR"))	return DEV_ERROR;
 		if(s.equals("USER_INFO")) 	return USER_INFO;
+		if(s.equals("USER_IMPORTANT")) 	return USER_IMPORTANTINFO;
 		if(s.equals("USER_WARNING"))return USER_WARNING;
 		if(s.equals("USER_ERROR")) 	return USER_ERROR;
 		return DEV_DEBUG;
@@ -60,6 +64,8 @@ public class ConsoleLogLevel{
 		switch (msgKind) {
 		case DevDEBUG:
 			return DEV_DEBUG;
+		case UserImportantINFO:
+			return USER_IMPORTANTINFO;
 		case UserINFO:
 			return USER_INFO;
 		case DevINFO:

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/EclipseMessagingSystem.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/EclipseMessagingSystem.java
@@ -218,17 +218,20 @@ public class EclipseMessagingSystem extends MessagingSystem {
 		getConsoleIO().clear();
 	}
 	
+	/**
+	 * This method dispatches the messages between the console and error log view
+	 * DevError and DevWarning go in both
+	 * UserError and UserWarning go only in the colsole
+	 */
 	@Override
 	public void log(Kind msgKind, String message, String messageGroup) {
 		
 		// some error message should go to the eclipse error view
 		switch (msgKind) {
-		case UserWARNING:
 		case DevWARNING:
 			if(messageGroup ==  null || !messageGroup.isEmpty())
 				Activator.getDefault().getLog().log(new Status(IStatus.WARNING, messageGroup, IStatus.WARNING, message != null ? message : "<null>",null));
 			break;
-		case UserERROR:
 		case DevERROR:
 			if(messageGroup ==  null || !messageGroup.isEmpty())
 				Activator.getDefault().getLog().log(new Status(IStatus.ERROR, messageGroup, IStatus.ERROR, message != null ? message : "<null>",null));
@@ -240,24 +243,23 @@ public class EclipseMessagingSystem extends MessagingSystem {
 		if(ConsoleLogLevel.isLevelEnoughToLog(ConsoleLogLevel.kind2Level(msgKind), getConsoleLogLevel())){
 			getConsoleIO().print(getConsoleMessageFor(msgKind,message));
 		}
-		// currently redirect to stdio
-		//StdioSimpleMessagingSystem stdioRedirect = new StdioSimpleMessagingSystem();
-		//stdioRedirect.log(msgKind, message, messageGroup);
 	}
 
 	
-
+	/**
+	 * This method dispatches the messages between the console and error log view
+	 * DevError and DevWarning go in both
+	 * UserError and UserWarning go only in the colsole
+	 */
 	@Override
 	public void log(Kind msgKind, String message, String messageGroup, Throwable throwable) {
 		
 		// some error message should go to the eclipse error view
 		switch (msgKind) {
-		case UserWARNING:
 		case DevWARNING:
 			if(messageGroup ==  null || !messageGroup.isEmpty())
 				Activator.getDefault().getLog().log(new Status(IStatus.WARNING, messageGroup, IStatus.WARNING, message != null ? message : "<null>",throwable));
 			break;
-		case UserERROR:
 		case DevERROR:
 			if(messageGroup ==  null || !messageGroup.isEmpty())
 				Activator.getDefault().getLog().log(new Status(IStatus.ERROR, messageGroup, IStatus.ERROR, message != null ? message : "<null>",throwable));
@@ -416,40 +418,6 @@ public class EclipseMessagingSystem extends MessagingSystem {
 		this.progressBarMaxDepth = progressBarMaxDepth;
 	}
 	
-	
-	/*
-	class ProgressWrapperStarter extends org.eclipse.ui.progress.UIJob{
-		ProgressWrapper progressWrapper; 
-		IProgressMonitor progressMonitor;
-		EclipseMessagingSystem logger;
-		
-		public ProgressWrapperStarter(ProgressWrapper progressWrapper, IProgressMonitor progressMonitor, EclipseMessagingSystem logger){
-			super("adding progress monitor");
-			this.progressMonitor = progressMonitor;
-			this.progressWrapper = progressWrapper;
-			this.logger = logger;
-		}
-		@Override
-		public IStatus runInUIThread(IProgressMonitor arg0) {
-			try {
-
-				IWorkbench wb = PlatformUI.getWorkbench();
-				IProgressService ps = wb.getProgressService();
-				ps.busyCursorWhile(progressWrapper);
-
-				logger.log(Kind.DevINFO, "["+this.getClass()+"]progressWrapper created" , this.getClass().toString());
-			} catch (InvocationTargetException e) {
-				logger.log(Kind.DevWARNING, "["+progressWrapper.getRootProgressGroup()+"] cannot create progress monitor, => log only. "+e.getMessage(), progressWrapper.getRootProgressGroup(), e);
-				//mustLog = true;
-			} catch (InterruptedException e) {
-				logger.log(Kind.DevWARNING, "["+progressWrapper.getRootProgressGroup()+"] cannot create progress monitor, => log only. "+e.getMessage(), progressWrapper.getRootProgressGroup(), e);
-				//mustLog = true;
-			}
-			return null;
-		}
-		
-	}
-	*/
 	/**
 	 * Show the console view on this MessagingSystem console
 	 */

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/EclipseMessagingSystem.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/EclipseMessagingSystem.java
@@ -31,6 +31,7 @@ import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.mes
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.message.DebugMessage;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.message.DebugWarningMessage;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.message.ErrorMessage;
+import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.message.ImportantMessage;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.message.InfoMessage;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.message.WarningMessage;
 import org.eclipse.gemoc.commons.messagingsystem.api.reference.Reference;
@@ -368,6 +369,8 @@ public class EclipseMessagingSystem extends MessagingSystem {
 			return new DebugMessage(message+"\n");
 		case UserINFO:
 			return new InfoMessage(message+"\n");
+		case UserImportantINFO:
+			return new ImportantMessage(message+"\n");
 		case DevINFO:
 			return new DebugMessage(message+"\n");
 		case UserWARNING:

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/ConsoleIO.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/ConsoleIO.java
@@ -109,11 +109,25 @@ abstract public class ConsoleIO {
 	abstract public void print(ConsoleMessage message);
 	
 	/**
-	 * this methods allow to change the color of futur message
+	 * this methods allow to change the color of future messages
 	 * (this is because a simple change of current stream color, change the color for all messages, even previous ones ...) 
 	 * @param c
 	 */
 	abstract public void changeColor(Color c);
+	
+	/**
+	 * this methods allow to change the style and color of future messages
+	 * (this is because a simple change of current stream color, change the color for all messages, even previous ones ...) 
+	 * @param c
+	 * @param style
+	 */
+	abstract public void changeStyle(Color c, int style);
+	/**
+	 * this methods allow to change the style of future messages
+	 * (this is because a simple change of current stream color, change the color for all messages, even previous ones ...) 
+	 * @param style
+	 */
+	abstract public void changeFontStyle(int style);
 	
 	abstract public void println(ConsoleMessage message);
 	//////////////////////////////////////

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/EclipseConsoleIO.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/EclipseConsoleIO.java
@@ -25,6 +25,7 @@ import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.mes
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.preferences.PreferenceConstants;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IOConsoleOutputStream;
@@ -190,6 +191,19 @@ public class EclipseConsoleIO extends ConsoleIO implements IPropertyChangeListen
 			// need to change to another stream for the new color
 			changeStream(); // reset the stream
 			((IOConsoleOutputStream) getOutputStream()).setColor(c);
+		}
+	}
+	/**
+	 * this methods allow to change the color of futur message
+	 * (this is because a simple change of current stream color, change the color for all messages, even previous ones ...) 
+	 * @param c
+	 */
+	public void changeFontStyle(Color c){
+		Color previousColor = ((IOConsoleOutputStream) getOutputStream()).getColor();
+		if( (c==null && c!= previousColor) || (c!=null && !c.equals(previousColor)) ){
+			// need to change to another stream for the new color
+			changeStream(); // reset the stream
+			((IOConsoleOutputStream) getOutputStream()).setFontStyle(SWT.NORMAL);
 		}
 	}
 	/**

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/EclipseConsoleIO.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/EclipseConsoleIO.java
@@ -25,7 +25,6 @@ import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.mes
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.preferences.PreferenceConstants;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IOConsoleOutputStream;
@@ -117,7 +116,7 @@ public class EclipseConsoleIO extends ConsoleIO implements IPropertyChangeListen
 			// support for large string !
 			Job myJob = new Job("Writing a large string to the console") {
 			      public IStatus run(IProgressMonitor monitor) {
-			    	  safePrint( message.getMessage(), message.getColor(), monitor);
+			    	  safePrint( message.getMessage(), message.getColor(), message.getStyle(), monitor);
 			         return new Status(IStatus.OK, "fr.irisa.triskell.eclipse.utils", "large message printed to the console");
 			      }
 			   };
@@ -134,7 +133,7 @@ public class EclipseConsoleIO extends ConsoleIO implements IPropertyChangeListen
 			// support for reasonnable sized string
 			Runnable r = new Runnable() {
 				public void run() {
-					changeColor(message.getColor());
+					changeStyle(message.getColor(), message.getStyle());
 					String justifiedMsg = justifyMessage(message.getMessage());
 					if(!((IOConsoleOutputStream)getOutputStream()).isClosed()){
 						try {
@@ -151,7 +150,7 @@ public class EclipseConsoleIO extends ConsoleIO implements IPropertyChangeListen
 	/** deal with not justified and large string
 	 * this is because large string may block Eclipse UI
 	 */
-	protected void safePrint(String message, Color c, IProgressMonitor monitor){
+	protected void safePrint(String message, Color c, int style, IProgressMonitor monitor){
 		try {
 			String justifiedMsg = justifyMessage(message);
 			if(justifiedMsg.length() > LARGE_MESSAGE_SIZE){
@@ -163,28 +162,30 @@ public class EclipseConsoleIO extends ConsoleIO implements IPropertyChangeListen
 					start = LARGE_MESSAGE_SIZE*i;
 					end = LARGE_MESSAGE_SIZE*i + LARGE_MESSAGE_SIZE;
 					changeStream();
-					changeColor(c);
+					changeStyle(c, style);
 					((IOConsoleOutputStream)getOutputStream()).write(justifiedMsg.substring(start, end));
 					monitor.worked(1);
 				}
 				changeStream();
-				changeColor(c);
+				changeStyle(c, style);
 				((IOConsoleOutputStream)getOutputStream()).write(justifiedMsg.substring(end, justifiedMsg.length()));
 				monitor.done();
 			}
 			else{
-				changeColor(c);
+				changeStyle(c, style);
 				((IOConsoleOutputStream)getOutputStream()).write(justifiedMsg);
 			}
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}
+	
 	/**
-	 * this methods allow to change the color of futur message
+	 * this methods allow to change the color of future message
 	 * (this is because a simple change of current stream color, change the color for all messages, even previous ones ...) 
 	 * @param c
 	 */
+	@Override
 	public void changeColor(Color c){
 		Color previousColor = ((IOConsoleOutputStream) getOutputStream()).getColor();
 		if( (c==null && c!= previousColor) || (c!=null && !c.equals(previousColor)) ){
@@ -194,16 +195,33 @@ public class EclipseConsoleIO extends ConsoleIO implements IPropertyChangeListen
 		}
 	}
 	/**
-	 * this methods allow to change the color of futur message
+	 * this methods allow to change the color and font style of future message
 	 * (this is because a simple change of current stream color, change the color for all messages, even previous ones ...) 
 	 * @param c
 	 */
-	public void changeFontStyle(Color c){
+	@Override
+	public void changeStyle(Color c, int style){
 		Color previousColor = ((IOConsoleOutputStream) getOutputStream()).getColor();
-		if( (c==null && c!= previousColor) || (c!=null && !c.equals(previousColor)) ){
+		int previousStyle = ((IOConsoleOutputStream) getOutputStream()).getFontStyle();
+		if( (c==null && c!= previousColor) || (c!=null && !c.equals(previousColor)) || style!= previousStyle ){
 			// need to change to another stream for the new color
 			changeStream(); // reset the stream
-			((IOConsoleOutputStream) getOutputStream()).setFontStyle(SWT.NORMAL);
+			((IOConsoleOutputStream) getOutputStream()).setColor(c);
+			((IOConsoleOutputStream) getOutputStream()).setFontStyle(style);
+		}
+	}
+	/**
+	 * this methods allow to change the font style of future message
+	 * (this is because a simple change of current stream color, change the color for all messages, even previous ones ...) 
+	 * @param style
+	 */
+	@Override
+	public void changeFontStyle(int style){
+		int previousStyle = ((IOConsoleOutputStream) getOutputStream()).getFontStyle();
+		if( style!= previousStyle ){
+			// need to change to another stream for the new style
+			changeStream(); // reset the stream
+			((IOConsoleOutputStream) getOutputStream()).setFontStyle(style);
 		}
 	}
 	/**
@@ -224,7 +242,7 @@ public class EclipseConsoleIO extends ConsoleIO implements IPropertyChangeListen
 		// add the carriage return
 		Runnable r = new Runnable() {
 			public void run() {
-				changeColor(message.getColor());
+				changeStyle(message.getColor(), message.getStyle());
 				if(!((IOConsoleOutputStream)getOutputStream()).isClosed()){
 					try {
 						((IOConsoleOutputStream)getOutputStream()).write("\n");

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/ConsoleMessage.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/ConsoleMessage.java
@@ -10,23 +10,39 @@
  *******************************************************************************/
 package org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.message;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 
 public class ConsoleMessage {
 
 	// some default colors that can be used
-	public static final Color INFO = null; // make eclipse use default console text color  
+	public static final Color INFO = null; // make eclipse use default console text color    
+	public static final Color IMPORTANT = new Color(null, 0,0,192);
 	public static final Color DEBUG = new Color(null, 0,128,0);
 	public static final Color DEBUG_WARNING = new Color(null, 128,128,0);
 	public static final Color DEBUG_ERROR = new Color(null, 128,64,0);
 	public static final Color ERROR = new Color(null, 192,0,0);
 	public static final Color WARNING = new Color(null, 215,150,0);
 	
+	public static final int INFO_STYLE = SWT.NORMAL; // make eclipse use default console text color    
+	public static final int IMPORTANT_STYLE = SWT.BOLD;
+	public static final int DEBUG_STYLE = SWT.NORMAL;
+	public static final int DEBUG_WARNING_STYLE = SWT.NORMAL;
+	public static final int DEBUG_ERROR_STYLE = SWT.NORMAL;
+	public static final int ERROR_STYLE = SWT.NORMAL;
+	public static final int WARNING_STYLE = SWT.NORMAL;
+	
+	
+	
 	/**
 	 * The color of the displayed message.
 	 * @see org.eclipse.swt.graphics.Color
 	 */
 	protected Color color;
+	/**
+	 * The font style of the displayed message.
+	 */
+	protected int style;
 	
 	/**
 	 * The message to be displayed.
@@ -34,10 +50,11 @@ public class ConsoleMessage {
 	protected String message;
 	
 
-	public ConsoleMessage( String message, Color color) {
+	public ConsoleMessage( String message, Color color, int style) {
 		super();
 		this.color = color;
 		this.message = message;
+		this.style = style;
 	}
 	
 	/**
@@ -46,6 +63,14 @@ public class ConsoleMessage {
 	 */
 	public Color getColor() {
 		return color;
+	}
+	
+	/**
+	 * 
+	 * @return
+	 */
+	public int getStyle() {
+		return style;
 	}
 	
 	/**

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/DebugErrorMessage.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/DebugErrorMessage.java
@@ -13,7 +13,7 @@ package org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.me
 public class DebugErrorMessage extends ConsoleMessage {
 
 	public DebugErrorMessage(String content) {
-		super(content, ConsoleMessage.DEBUG_ERROR);
+		super(content, ConsoleMessage.DEBUG_ERROR, ConsoleMessage.DEBUG_ERROR_STYLE);
 	}
 	
 }

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/DebugMessage.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/DebugMessage.java
@@ -13,7 +13,7 @@ package org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.me
 public class DebugMessage extends ConsoleMessage {
 
 	public DebugMessage(String content) {
-		super(content, ConsoleMessage.DEBUG);
+		super(content, ConsoleMessage.DEBUG, ConsoleMessage.DEBUG_STYLE);
 	}
 	
 }

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/ErrorMessage.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/ErrorMessage.java
@@ -13,7 +13,7 @@ package org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.me
 public class ErrorMessage extends ConsoleMessage {
 
 	public ErrorMessage(String content) {
-		super(content, ConsoleMessage.ERROR);
+		super(content, ConsoleMessage.ERROR, ConsoleMessage.ERROR_STYLE);
 	}
 	
 }

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/ImportantMessage.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/ImportantMessage.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.message;
 
-public class DebugWarningMessage extends ConsoleMessage {
+public class ImportantMessage extends ConsoleMessage {
 
-	public DebugWarningMessage(String content) {
-		super(content, ConsoleMessage.DEBUG_WARNING, ConsoleMessage.DEBUG_WARNING_STYLE);
+	public ImportantMessage(String content) {
+		super(content, ConsoleMessage.IMPORTANT, ConsoleMessage.IMPORTANT_STYLE);
 	}
 	
 }

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/InfoMessage.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/InfoMessage.java
@@ -13,7 +13,7 @@ package org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.me
 public class InfoMessage extends ConsoleMessage {
 
 	public InfoMessage(String content) {
-		super(content, ConsoleMessage.INFO);
+		super(content, ConsoleMessage.INFO, ConsoleMessage.INFO_STYLE);
 	}
 	
 }

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/WarningMessage.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/internal/console/message/WarningMessage.java
@@ -14,7 +14,7 @@ package org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.me
 public class WarningMessage extends ConsoleMessage {
 
 	public WarningMessage(String content) {
-		super(content, ConsoleMessage.WARNING);
+		super(content, ConsoleMessage.WARNING, ConsoleMessage.WARNING_STYLE);
 	}
 	
 }


### PR DESCRIPTION
Improve usability of the Messaging system

- add a new level for user messages : important. It allows to highlight the most important messages. In the eclipse console it displays using a blue bold font.
- only dev error and warning go to the Eclipse Error log view, user error and warning go only to the console