### PR TITLE
Upgrade melange 01 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build.acceleo
 *._trace
 **/gemoc-gen/*
 **/xtend-gen/*
+node_modules
+/package-lock.json

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 node {
-	properties([[$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false], buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '1', daysToKeepStr: '', numToKeepStr: '10')), pipelineTriggers([[$class: 'PeriodicFolderTrigger', interval: '15m']])])
+	properties([disableConcurrentBuilds(), [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false], buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '1', daysToKeepStr: '', numToKeepStr: '10')), pipelineTriggers([[$class: 'PeriodicFolderTrigger', interval: '15m']])])
    
 	catchError {
 	   def mvnHome

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,14 @@
 #!groovy
 node {
    properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10']]]);
+
 	catchError {
 	   def mvnHome
 	   stage('Preparation') {
-	   
-	      // Get code from GitHub repositories
+   		  // Wipe the workspace so we are building completely clean
+  		  deleteDir()
+  		  	   
+		  // Get code from GitHub repositories
 	
 	      // this will check if there is a branch with the same name as the current branch (ie. the branch containing this Jenkinsfile) and use that for the checkout, but if there is no
 	      // branch with the same name it will fall back to the master branch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,5 +50,5 @@ node {
 	      archiveArtifacts '**/target/products/*.zip,**/gemoc-studio/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/target/repository/**'
 	   }
    }
-   step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: '', sendToIndividuals: true])
+   step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: 'didider.vojtisek@inria.fr', sendToIndividuals: true])
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,9 +46,9 @@ node {
 	      }
 	   }	   
 	   stage('Deployment') {
-	      junit '**/target/surefire-reports/TEST-*.xml'
+	      junit keepLongStdio: true, testResults: '**/target/surefire-reports/TEST-*.xml'
 	      archiveArtifacts '**/target/products/*.zip,**/gemoc-studio/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/target/repository/**'
 	   }
    }
-   step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: 'didider.vojtisek@inria.fr', sendToIndividuals: true])
+   step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: 'didier.vojtisek@inria.fr', sendToIndividuals: true])
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 node {
-   properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10']]]);
-
+	properties([[$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false], buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '1', daysToKeepStr: '', numToKeepStr: '10')), pipelineTriggers([[$class: 'PeriodicFolderTrigger', interval: '15m']])])
+   
 	catchError {
 	   def mvnHome
 	   stage('Preparation') {

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/Activator.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/Activator.java
@@ -12,6 +12,7 @@ package org.eclipse.gemoc.commons.eclipse.messagingsystem.ui;
 
 import java.io.PrintStream;
 
+import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.helper.TeeOutputStream;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.EclipseConsoleOutputStream;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.ConsoleIO;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.internal.console.EclipseConsoleIO;
@@ -106,8 +107,8 @@ public class Activator extends AbstractUIPlugin {
 		return consoleIO;
 	}
 
-	protected PrintStream OriginalSystemOut = null;
-	protected PrintStream OriginalSystemErr = null;
+	protected PrintStream originalSystemOut = null;
+	protected PrintStream originalSystemErr = null;
 
 	/**
 	 * set the current System.out and System.err so they are redirected to our
@@ -115,17 +116,19 @@ public class Activator extends AbstractUIPlugin {
 	 */
 	public void captureSystemOutAndErr() {
 		Activator.getDefault().getConsoleIO().print("Redirecting System.out and System.err to this console.\n");
-		if (OriginalSystemOut != System.out) {
-			OriginalSystemOut = System.out;
-			PrintStream outPrintStream = new PrintStream(
+		if (originalSystemOut != System.out) {
+			originalSystemOut = System.out;
+			TeeOutputStream teeOutputStream = new TeeOutputStream(
+					originalSystemOut, 
 					new EclipseConsoleOutputStream(Activator.getDefault().getConsoleIO(), false));
-			System.setOut(outPrintStream);
+			System.setOut(new PrintStream(teeOutputStream));
 		}
-		if (OriginalSystemErr != System.err) {
-			OriginalSystemOut = System.out;
-			PrintStream errPrintStream = new PrintStream(
+		if (originalSystemErr != System.err) {
+			originalSystemErr = System.err;
+			TeeOutputStream teeOutputStream = new TeeOutputStream(
+					originalSystemErr,
 					new EclipseConsoleOutputStream(Activator.getDefault().getConsoleIO(), true));
-			System.setErr(errPrintStream);
+			System.setErr(new PrintStream(teeOutputStream));
 		}
 	}
 
@@ -139,12 +142,12 @@ public class Activator extends AbstractUIPlugin {
 			System.err.flush();
 		if(consoleIO != null)
 			consoleIO.print("Stopping redirection of System.out and System.err to this console.\n");
-		if (OriginalSystemOut != null)
-			System.setOut(OriginalSystemOut);
-		if (OriginalSystemErr != null)
-			System.setErr(OriginalSystemErr);
-		OriginalSystemOut = null;
-		OriginalSystemErr = null;
+		if (originalSystemOut != null)
+			System.setOut(originalSystemOut);
+		if (originalSystemErr != null)
+			System.setErr(originalSystemErr);
+		originalSystemOut = null;
+		originalSystemErr = null;
 	}
 
 }

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/helper/TeeOutputStream.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/src/main/java/org/eclipse/gemoc/commons/eclipse/messagingsystem/ui/helper/TeeOutputStream.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Inria and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.helper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public final class TeeOutputStream extends OutputStream {
+
+	private final OutputStream out;
+	private final OutputStream tee;
+
+	public TeeOutputStream(OutputStream out, OutputStream tee) {
+		if (out == null)
+			throw new NullPointerException();
+		else if (tee == null)
+			throw new NullPointerException();
+
+		this.out = out;
+		this.tee = tee;
+	}
+
+	@Override
+	public void write(int b) throws IOException {
+		out.write(b);
+		tee.write(b);
+	}
+
+	@Override
+	public void write(byte[] b) throws IOException {
+		out.write(b);
+		tee.write(b);
+	}
+
+	@Override
+	public void write(byte[] b, int off, int len) throws IOException {
+		out.write(b, off, len);
+		tee.write(b, off, len);
+	}
+
+	@Override
+	public void flush() throws IOException {
+		out.flush();
+		tee.flush();
+	}
+
+	@Override
+	public void close() throws IOException {
+		out.close();
+		tee.close();
+	}
+}

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.pde/src/org/eclipse/gemoc/commons/eclipse/pde/manifest/ManifestChanger.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.pde/src/org/eclipse/gemoc/commons/eclipse/pde/manifest/ManifestChanger.java
@@ -15,6 +15,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.util.Map.Entry;
 import java.util.jar.Attributes.Name;
 import java.util.jar.Manifest;
@@ -107,7 +110,24 @@ public class ManifestChanger {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			writeManifest(out);
 			ByteArrayInputStream is = new ByteArrayInputStream(out.toByteArray());
-			outputFile.setContents(is, 1, new NullProgressMonitor());			
+			
+			try{
+				if (outputFile.exists()) {
+					if(!isStreamEqual(is, outputFile.getContents(true))){
+						// use a new stream because isStreamEqual has used and closed the previous one
+						outputFile.setContents(new ByteArrayInputStream(out.toByteArray()), true, true, new NullProgressMonitor());	
+					}
+				} else {
+					outputFile.create(is, true, new NullProgressMonitor());
+				}
+			}
+			finally{
+				try {
+					if (out != null) out.close(); 
+				} catch(IOException e) {
+					//closing quielty
+				}
+			}
 		}
 	}
 	public void addPluginDependency(String plugin) throws BundleException, IOException, CoreException {
@@ -130,5 +150,39 @@ public class ManifestChanger {
 	}
 	public void addAttributes(String attributeName, String value){
 		_manifest.getMainAttributes().putValue(attributeName, value);
+	}
+	
+	private static boolean isStreamEqual(InputStream i1, InputStream i2)
+	        throws IOException {
+
+	    ReadableByteChannel ch1 = Channels.newChannel(i1);
+	    ReadableByteChannel ch2 = Channels.newChannel(i2);
+
+	    ByteBuffer buf1 = ByteBuffer.allocateDirect(1024);
+	    ByteBuffer buf2 = ByteBuffer.allocateDirect(1024);
+
+	    try {
+	        while (true) {
+
+	            int n1 = ch1.read(buf1);
+	            int n2 = ch2.read(buf2);
+
+	            if (n1 == -1 || n2 == -1) return n1 == n2;
+
+	            buf1.flip();
+	            buf2.flip();
+
+	            for (int i = 0; i < Math.min(n1, n2); i++)
+	                if (buf1.get() != buf2.get())
+	                    return false;
+
+	            buf1.compact();
+	            buf2.compact();
+	        }
+
+	    } finally {
+	        if (i1 != null) i1.close();
+	        if (i2 != null) i2.close();
+	    }
 	}
 }

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<properties>
-		<eclipse.version.name>Oxygen.1A</eclipse.version.name>
+		<eclipse.version.name>Oxygen.2</eclipse.version.name>
 		<!-- override these values using -D option on the maven command line on the CI (see jenkinsfile for CI configuration)-->		
 		<studio.variant>Local build</studio.variant>
 		<branch.variant>Unknown</branch.variant>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/launch_conf/open-junit-eclipse-test-worskpace.launch
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/launch_conf/open-junit-eclipse-test-worskpace.launch
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="true"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearws" value="false"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/open-junit-eclipse-test-worskpace"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="org.eclipse.sdk.ide"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="true"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/launch_conf/org.eclipse.gemoc.studio.tests.system.launch
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/launch_conf/org.eclipse.gemoc.studio.tests.system.launch
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.eclipse.gemoc.studio.tests.system/xtend-gen/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/org.eclipse.gemoc.studio.tests.system/console.output}"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/java-8-oracle"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.gemoc.studio.tests.system.lwb.userstory.CreateSingleSequentialLanguageFromOfficialFSM_Test"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.gemoc.studio.tests.system"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="org.eclipse.sdk.ide"/>
+<booleanAttribute key="run_in_ui_thread" value="false"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="true"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateLangRuntime4OfficialSampleLegacyFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateLangRuntime4OfficialSampleLegacyFSM_Test.xtend
@@ -15,7 +15,6 @@ import org.eclipse.core.resources.IProject
 import org.eclipse.xtext.junit4.AbstractXtextTests
 import org.eclipse.xtext.junit4.InjectWith
 import org.eclipse.xtext.junit4.XtextRunner
-import org.eclipse.xtext.junit4.ui.util.IResourcesSetupUtil
 import org.junit.After
 import org.junit.Before
 import org.junit.FixMethodOrder
@@ -33,6 +32,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem
 import com.google.inject.Injector
 import java.util.ArrayList
 import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
 
 /**
  * Checks that the provided official sample can compile without error 
@@ -70,6 +70,7 @@ public class GenerateLangRuntime4OfficialSampleLegacyFSM_Test extends AbstractXt
 		super.setUp
 		helper.init
 		IResourcesSetupUtil::cleanWorkspace
+		IResourcesSetupUtil::reallyWaitForAutoBuild
 		
 		// try to respect build order in order to ease compilation, this will speed up the test
 		helper.deployProject(PROJECT_NAME+".model",BASE_FOLDER_NAME+"/"+PROJECT_NAME+".model.zip")
@@ -84,9 +85,12 @@ public class GenerateLangRuntime4OfficialSampleLegacyFSM_Test extends AbstractXt
 		//helper.deployProject(PROJECT_NAME2+".design",BASE_FOLDER_NAME+"/"+PROJECT_NAME2+".design.zip")
 		
 		IResourcesSetupUtil::reallyWaitForAutoBuild
+		WorkspaceTestHelper::reallyWaitForJobs(4)
 		melangeHelper.cleanAll(MELANGE_FILE)
 		melangeHelper.cleanAll(MELANGE_FILE2)
+		IResourcesSetupUtil::fullBuild
 		IResourcesSetupUtil::reallyWaitForAutoBuild
+		WorkspaceTestHelper::reallyWaitForJobs(4)
 		
 		val ArrayList<Throwable> thrownException = newArrayList()
 		Display.^default.syncExec([

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateTrace4OfficialSampleLegacyFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateTrace4OfficialSampleLegacyFSM_Test.xtend
@@ -80,6 +80,8 @@ public class GenerateTrace4OfficialSampleLegacyFSM_Test extends AbstractXtextTes
 		melangeProject2 = helper.deployProject(PROJECT_NAME2+".xsfsm",BASE_FOLDER_NAME+"/"+PROJECT_NAME2+".xsfsm.zip")
 		//helper.deployProject(PROJECT_NAME2+".design",BASE_FOLDER_NAME+"/"+PROJECT_NAME2+".design.zip")
 		
+		IResourcesSetupUtil::cleanBuild()
+		IResourcesSetupUtil::reallyWaitForAutoBuild	
 		IResourcesSetupUtil::fullBuild
 		IResourcesSetupUtil::reallyWaitForAutoBuild
 		WorkspaceTestHelper::reallyWaitForJobs(4)
@@ -104,9 +106,10 @@ public class GenerateTrace4OfficialSampleLegacyFSM_Test extends AbstractXtextTes
 			}
 		])
 		thrownException.forall[e| throw new Exception(e)] // rethrown exception that was executed in the ui thread
-		
-		IResourcesSetupUtil::reallyWaitForAutoBuild
-		
+		IResourcesSetupUtil::cleanBuild()
+		IResourcesSetupUtil::reallyWaitForAutoBuild		
+		IResourcesSetupUtil::fullBuild
+		IResourcesSetupUtil::reallyWaitForAutoBuild	
 		WorkspaceTestHelper::reallyWaitForJobs(50)
 		IResourcesSetupUtil::reallyWaitForAutoBuild
 		

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateTrace4OfficialSampleLegacyFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateTrace4OfficialSampleLegacyFSM_Test.xtend
@@ -80,8 +80,6 @@ public class GenerateTrace4OfficialSampleLegacyFSM_Test extends AbstractXtextTes
 		melangeProject2 = helper.deployProject(PROJECT_NAME2+".xsfsm",BASE_FOLDER_NAME+"/"+PROJECT_NAME2+".xsfsm.zip")
 		//helper.deployProject(PROJECT_NAME2+".design",BASE_FOLDER_NAME+"/"+PROJECT_NAME2+".design.zip")
 		
-		IResourcesSetupUtil::cleanBuild()
-		IResourcesSetupUtil::reallyWaitForAutoBuild	
 		IResourcesSetupUtil::fullBuild
 		IResourcesSetupUtil::reallyWaitForAutoBuild
 		WorkspaceTestHelper::reallyWaitForJobs(4)
@@ -106,10 +104,8 @@ public class GenerateTrace4OfficialSampleLegacyFSM_Test extends AbstractXtextTes
 			}
 		])
 		thrownException.forall[e| throw new Exception(e)] // rethrown exception that was executed in the ui thread
-		IResourcesSetupUtil::cleanBuild()
-		IResourcesSetupUtil::reallyWaitForAutoBuild		
-		IResourcesSetupUtil::fullBuild
-		IResourcesSetupUtil::reallyWaitForAutoBuild	
+	
+		IResourcesSetupUtil::fullBuild	
 		WorkspaceTestHelper::reallyWaitForJobs(50)
 		IResourcesSetupUtil::reallyWaitForAutoBuild
 		

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateTrace4OfficialSampleLegacyFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateTrace4OfficialSampleLegacyFSM_Test.xtend
@@ -15,7 +15,6 @@ import org.eclipse.core.resources.IProject
 import org.eclipse.xtext.junit4.AbstractXtextTests
 import org.eclipse.xtext.junit4.InjectWith
 import org.eclipse.xtext.junit4.XtextRunner
-import org.eclipse.xtext.junit4.ui.util.IResourcesSetupUtil
 import org.junit.After
 import org.junit.Before
 import org.junit.FixMethodOrder
@@ -27,6 +26,10 @@ import org.eclipse.gemoc.xdsmlframework.test.lib.MelangeUiInjectorProvider
 import org.eclipse.swt.widgets.Display
 import org.eclipse.gemoc.xdsmlframework.test.lib.WorkspaceTestHelper
 import java.util.ArrayList
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
+import org.junit.BeforeClass
+import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot
 
 /**
  * Checks that the provided official sample can compile without error 
@@ -36,7 +39,9 @@ import java.util.ArrayList
 @FixMethodOrder(MethodSorters::NAME_ASCENDING)
 public class GenerateTrace4OfficialSampleLegacyFSM_Test extends AbstractXtextTests
 {
-	@Inject MelangeWorkspaceTestHelper helper
+	@Inject MelangeWorkspaceTestHelper melangeHelper
+	static WorkspaceTestHelper helper = new WorkspaceTestHelper
+	private static SWTWorkbenchBot	bot;
 	IProject melangeProject
 	IProject melangeProject2
 	static final String BASE_FOLDER_NAME = "tests-inputs-gen/SequentialFSM"
@@ -45,7 +50,16 @@ public class GenerateTrace4OfficialSampleLegacyFSM_Test extends AbstractXtextTes
 	static final String MELANGE_FILE = PROJECT_NAME+"/src/org/eclipse/gemoc/sample/legacyfsm/fsm/FSM.melange"
 	static final String PROJECT_NAME2 = BASE_PROJECT_NAME+".xsfsm"
 	static final String MELANGE_FILE2 = PROJECT_NAME2+"/src/org/eclipse/gemoc/sample/legacyfsm/xsfsm/language/XSFSM.melange"
-	
+
+	@BeforeClass
+	def static void beforeClass() throws Exception {
+		helper.init
+		bot = new SWTWorkbenchBot()
+		SWTBotPreferences.TIMEOUT = WorkspaceTestHelper.SWTBotPreferencesTIMEOUT_4_GEMOC;
+		bot.resetWorkbench
+		IResourcesSetupUtil::cleanWorkspace
+	}
+		
 	@Before
 	override setUp() {
 		helper.setTargetPlatform
@@ -66,7 +80,9 @@ public class GenerateTrace4OfficialSampleLegacyFSM_Test extends AbstractXtextTes
 		melangeProject2 = helper.deployProject(PROJECT_NAME2+".xsfsm",BASE_FOLDER_NAME+"/"+PROJECT_NAME2+".xsfsm.zip")
 		//helper.deployProject(PROJECT_NAME2+".design",BASE_FOLDER_NAME+"/"+PROJECT_NAME2+".design.zip")
 		
+		IResourcesSetupUtil::fullBuild
 		IResourcesSetupUtil::reallyWaitForAutoBuild
+		WorkspaceTestHelper::reallyWaitForJobs(4)
 	}
 
 	@After
@@ -82,7 +98,7 @@ public class GenerateTrace4OfficialSampleLegacyFSM_Test extends AbstractXtextTes
 		val ArrayList<Throwable> thrownException = newArrayList()
 		Display.^default.syncExec([
 			try{
-				helper.generateTrace(MELANGE_FILE2, "XSFSM", PROJECT_NAME2+".trace")
+				melangeHelper.generateTrace(MELANGE_FILE2, "XSFSM", PROJECT_NAME2+".trace")
 			} catch (Exception e) {
 				thrownException.add(e)
 			}

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
@@ -59,6 +59,7 @@ public class CreateSingleSequentialLanguageFromOfficialFSM_Test extends Abstract
 		bot = new SWTWorkbenchBot()
 		// Set the SWTBot timeout
 		SWTBotPreferences.TIMEOUT = WorkspaceTestHelper.SWTBotPreferencesTIMEOUT_4_GEMOC;
+		helper.setTargetPlatform
 		bot.resetWorkbench
 		IResourcesSetupUtil::cleanWorkspace
 		WorkspaceTestHelper::reallyWaitForJobs(2)
@@ -75,6 +76,7 @@ public class CreateSingleSequentialLanguageFromOfficialFSM_Test extends Abstract
 	
 	@Before
 	override setUp() {
+		helper.setTargetPlatform
 		bot.resetWorkbench
 		// helps to reset the workspace state by closing menu as bot.resetWorkbench is not enough
 		val Keyboard key = KeyboardFactory.getSWTKeyboard();
@@ -107,6 +109,7 @@ public class CreateSingleSequentialLanguageFromOfficialFSM_Test extends Abstract
 		bot.menu("File").menu("New").menu("GEMOC Sequential xDSML Project").click();
 		bot.text().setText(PROJECT_NAME);
 		bot.button("Next >").click();
+		//bot.buttonWithLabel("Next >").click();
 		bot.button("Next >").click();
 		bot.textWithLabel("&Package name(*)").setText(BASE_NAME);
 				
@@ -128,6 +131,8 @@ public class CreateSingleSequentialLanguageFromOfficialFSM_Test extends Abstract
 		activeShell.bot.button("Finish").click()
 		//bot.button("Finish").click();
 
+		IResourcesSetupUtil::reallyWaitForAutoBuild
+		WorkspaceTestHelper::reallyWaitForJobs(4)
 		helper.assertProjectExists(PROJECT_NAME);
 
 		IResourcesSetupUtil.reallyWaitForAutoBuild();

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
@@ -64,11 +64,9 @@ public class CreateSingleSequentialLanguageFromOfficialFSM_Test extends Abstract
 		helper.deployProject(SOURCE_PROJECT_NAME+".model",BASE_FOLDER_NAME+"/"+SOURCE_PROJECT_NAME+".model.zip")
 		helper.deployProject(SOURCE_PROJECT_NAME+".k3dsa",BASE_FOLDER_NAME+"/"+SOURCE_PROJECT_NAME+".k3dsa.zip")
 		
-		WorkspaceTestHelper::reallyWaitForJobs(2)
-		IResourcesSetupUtil::reallyWaitForAutoBuild
 		IResourcesSetupUtil::fullBuild
 		IResourcesSetupUtil::reallyWaitForAutoBuild
-		WorkspaceTestHelper::reallyWaitForJobs(4)
+		WorkspaceTestHelper::reallyWaitForJobs(2)
 	}
 	
 	@Before

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
@@ -63,6 +63,12 @@ public class CreateSingleSequentialLanguageFromOfficialFSM_Test extends Abstract
 		IResourcesSetupUtil::cleanWorkspace
 		helper.deployProject(SOURCE_PROJECT_NAME+".model",BASE_FOLDER_NAME+"/"+SOURCE_PROJECT_NAME+".model.zip")
 		helper.deployProject(SOURCE_PROJECT_NAME+".k3dsa",BASE_FOLDER_NAME+"/"+SOURCE_PROJECT_NAME+".k3dsa.zip")
+		
+		WorkspaceTestHelper::reallyWaitForJobs(2)
+		IResourcesSetupUtil::reallyWaitForAutoBuild
+		IResourcesSetupUtil::fullBuild
+		IResourcesSetupUtil::reallyWaitForAutoBuild
+		WorkspaceTestHelper::reallyWaitForJobs(4)
 	}
 	
 	@Before
@@ -74,7 +80,9 @@ public class CreateSingleSequentialLanguageFromOfficialFSM_Test extends Abstract
 		// make sure we are on the correct perspective
 		bot.perspectiveById(XDSMLFrameworkUI.ID_PERSPECTIVE).activate()
 		val projExplorerBot = bot.viewByTitle("Project Explorer").bot
+		
 		IResourcesSetupUtil::reallyWaitForAutoBuild
+		WorkspaceTestHelper::reallyWaitForJobs(4)
 	}
 	
 	@After

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
@@ -61,9 +61,12 @@ public class CreateSingleSequentialLanguageFromOfficialFSM_Test extends Abstract
 		SWTBotPreferences.TIMEOUT = WorkspaceTestHelper.SWTBotPreferencesTIMEOUT_4_GEMOC;
 		bot.resetWorkbench
 		IResourcesSetupUtil::cleanWorkspace
+		WorkspaceTestHelper::reallyWaitForJobs(2)
+		IResourcesSetupUtil::reallyWaitForAutoBuild
 		helper.deployProject(SOURCE_PROJECT_NAME+".model",BASE_FOLDER_NAME+"/"+SOURCE_PROJECT_NAME+".model.zip")
 		helper.deployProject(SOURCE_PROJECT_NAME+".k3dsa",BASE_FOLDER_NAME+"/"+SOURCE_PROJECT_NAME+".k3dsa.zip")
 		
+		WorkspaceTestHelper::reallyWaitForJobs(2)
 		IResourcesSetupUtil::reallyWaitForAutoBuild
 		IResourcesSetupUtil::fullBuild
 		IResourcesSetupUtil::reallyWaitForAutoBuild

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
@@ -64,9 +64,10 @@ public class CreateSingleSequentialLanguageFromOfficialFSM_Test extends Abstract
 		helper.deployProject(SOURCE_PROJECT_NAME+".model",BASE_FOLDER_NAME+"/"+SOURCE_PROJECT_NAME+".model.zip")
 		helper.deployProject(SOURCE_PROJECT_NAME+".k3dsa",BASE_FOLDER_NAME+"/"+SOURCE_PROJECT_NAME+".k3dsa.zip")
 		
+		IResourcesSetupUtil::reallyWaitForAutoBuild
 		IResourcesSetupUtil::fullBuild
 		IResourcesSetupUtil::reallyWaitForAutoBuild
-		WorkspaceTestHelper::reallyWaitForJobs(2)
+		WorkspaceTestHelper::reallyWaitForJobs(4)
 	}
 	
 	@Before

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/DeployOfficialSampleLegacyFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/DeployOfficialSampleLegacyFSM_Test.xtend
@@ -57,7 +57,7 @@ public class DeployOfficialSampleLegacyFSM_Test extends AbstractXtextTests
 		bot.resetWorkbench
 		IResourcesSetupUtil::cleanWorkspace
 		IResourcesSetupUtil::reallyWaitForAutoBuild
-		WorkspaceTestHelper::reallyWaitForJobs(4)
+		WorkspaceTestHelper::reallyWaitForJobs(2)
 	}
 	
 	@Before
@@ -85,9 +85,7 @@ public class DeployOfficialSampleLegacyFSM_Test extends AbstractXtextTests
 		bot.tree().getTreeItem("GEMOC language workbench examples").expand();
 		bot.tree().getTreeItem("GEMOC language workbench examples").getNode("GEMOC FSM Language (Sequential)").select();
 	  	bot.button("Finish").click();
-		IResourcesSetupUtil::cleanBuild()
-		WorkspaceTestHelper::reallyWaitForJobs(2)
-		IResourcesSetupUtil::reallyWaitForAutoBuild
+
 		IResourcesSetupUtil::fullBuild
 		IResourcesSetupUtil::reallyWaitForAutoBuild
 		WorkspaceTestHelper::reallyWaitForJobs(4)

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/DeployOfficialSampleLegacyFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/DeployOfficialSampleLegacyFSM_Test.xtend
@@ -69,6 +69,7 @@ public class DeployOfficialSampleLegacyFSM_Test extends AbstractXtextTests
 		key.pressShortcut(Keystrokes.ESC);		
 		// make sure we are on the correct perspective
 		bot.perspectiveById(XDSMLFrameworkUI.ID_PERSPECTIVE).activate()
+		IResourcesSetupUtil::reallyWaitForAutoBuild
 	}
 	
 	@After
@@ -84,7 +85,7 @@ public class DeployOfficialSampleLegacyFSM_Test extends AbstractXtextTests
 		bot.tree().getTreeItem("GEMOC language workbench examples").expand();
 		bot.tree().getTreeItem("GEMOC language workbench examples").getNode("GEMOC FSM Language (Sequential)").select();
 	  	bot.button("Finish").click();
-
+		IResourcesSetupUtil::cleanBuild()
 		WorkspaceTestHelper::reallyWaitForJobs(2)
 		IResourcesSetupUtil::reallyWaitForAutoBuild
 		IResourcesSetupUtil::fullBuild

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/DeployOfficialSampleLegacyFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/DeployOfficialSampleLegacyFSM_Test.xtend
@@ -56,6 +56,8 @@ public class DeployOfficialSampleLegacyFSM_Test extends AbstractXtextTests
 		SWTBotPreferences.TIMEOUT = WorkspaceTestHelper.SWTBotPreferencesTIMEOUT_4_GEMOC;
 		bot.resetWorkbench
 		IResourcesSetupUtil::cleanWorkspace
+		IResourcesSetupUtil::reallyWaitForAutoBuild
+		WorkspaceTestHelper::reallyWaitForJobs(4)
 	}
 	
 	@Before
@@ -76,7 +78,7 @@ public class DeployOfficialSampleLegacyFSM_Test extends AbstractXtextTests
 	
 	@Test
 	def void test01_InstallLegacyFsm() throws Exception {
-		val activeShell = bot.activeShell // the focus is lost after click on "Browse..."
+		//val activeShell = bot.activeShell // the focus is lost after click on "Browse..."
 		bot.menu("File").menu("New").menu("Example...").click();
 		bot.tree().getTreeItem("GEMOC language workbench examples").select();
 		bot.tree().getTreeItem("GEMOC language workbench examples").expand();

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.fsm.k3dsa/META-INF/MANIFEST.MF
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.fsm.k3dsa/META-INF/MANIFEST.MF
@@ -1,5 +1,7 @@
+Manifest-Version: 1.0
 Bundle-SymbolicName: org.eclipse.gemoc.sample.legacyfsm.fsm.k3dsa;singleton:=true
-Export-Package: org.eclipse.gemoc.sample.legacyfsm.fsm.k3dsa,org.eclipse.gemoc.sample.legacyfsm.fsm.k3dsa
+Export-Package: org.eclipse.gemoc.sample.legacyfsm.fsm.k3dsa,
+ org.eclipse.gemoc.sample.legacyfsm.fsm.k3dsa
 Bundle-Name: org.eclipse.gemoc.sample.legacyfsm.fsm.k3dsa
 Bundle-Version: 1.0.0
 Bundle-ClassPath: .
@@ -13,4 +15,3 @@ Require-Bundle: fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version
  org.eclipse.gemoc.sample.legacyfsm.fsm.model;bundle-version="0.0.0";visibility:=private
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Manifest-Version: 1.0

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.fsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/fsm/FSM.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.fsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/fsm/FSM.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2016  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 package org.eclipse.gemoc.sample.legacyfsm.fsm;
 
 import fr.inria.diverse.melange.lib.IMetamodel;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.fsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/fsm/FSMMT.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.fsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/fsm/FSMMT.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2016  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 package org.eclipse.gemoc.sample.legacyfsm.fsm;
 
 import fr.inria.diverse.melange.lib.IModelType;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.fsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/fsm/StandaloneSetup.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.fsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/fsm/StandaloneSetup.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2016  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 package org.eclipse.gemoc.sample.legacyfsm.fsm;
 
 import fr.inria.diverse.melange.resource.MelangeRegistry;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/.classpath
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/.classpath
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/.classpath
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<classpath>
-	<classpathentry kind="src" path="src-gen"/>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
-</classpath>

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/build.properties
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/build.properties
@@ -1,0 +1,3 @@
+source.. = src,\n  src-gen
+bin.includes = META-INF/,\
+  .

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/build.properties
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/build.properties
@@ -1,3 +1,0 @@
-source.. = src,\n  src-gen
-bin.includes = META-INF/,\
-  .

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/model/XSFSM.dsl
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/model/XSFSM.dsl
@@ -1,10 +1,3 @@
-DSL org.eclipse.gemoc.sample.legacyfsm.xsfsm.XSFSM {
-	abstract-syntax {
-		ecore = "platform:/resource/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/model/XSFSM.ecore"
-	}
-	semantic {
-		k3 = "org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm.aspects.StateAspect",
-		"org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm.aspects.StateMachineAspect",
-		"org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm.aspects.TransitionAspect"
-	}
-}
+name = org.eclipse.gemoc.sample.legacyfsm.xsfsm.XSFSM
+ecore = platform:/resource/org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm/model/XSFSM.ecore
+k3 = org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm.aspects.StateAspect,org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm.aspects.StateMachineAspect,org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsm.aspects.TransitionAspect

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/build.properties
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/build.properties
@@ -10,5 +10,8 @@
 ###############################################################################
 #
 #Fri Oct 21 16:57:28 CEST 2016
-bin.includes=plugin.xml,META-INF/,.
+bin.includes = plugin.xml,\
+               META-INF/,\
+               .,\
+               model-gen/
 source..=src/,src-gen/,xtend-gen/

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/plugin.xml
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/plugin.xml
@@ -10,7 +10,7 @@
         Inria - initial API and implementation
  --><plugin>
   <extension point="org.eclipse.gemoc.gemoc_language_workbench.sequential.xdsml">
-    <XDSML_Definition modelLoader_class="org.eclipse.gemoc.executionframework.extensions.sirius.modelloader.DefaultModelLoader" name="org.eclipse.gemoc.sample.legacyfsm.xsfsm.XSFSM" xdsmlFilePath="/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src/org/eclipse/gemoc/sample/legacyfsm/xsfsm/language/XSFSM.melange">
+    <XDSML_Definition modelLoader_class="org.eclipse.gemoc.executionframework.extensions.sirius.modelloader.DefaultModelLoader" name="org.eclipse.gemoc.sample.legacyfsm.xsfsm.XSFSM" xdsmlFilePath="/org.eclipse.gemoc.sample.legacyfsm.xsfsm/bin/org/eclipse/gemoc/sample/legacyfsm/xsfsm/language/XSFSM.melange">
       <XDSML_Definition_Customization fileExtensions="fsm, xsfsm"/>
     </XDSML_Definition>
   </extension>

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/FsmFactory.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/FsmFactory.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2017  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/FsmPackage.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/FsmPackage.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2017  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/NamedElement.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/NamedElement.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2016  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/State.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/State.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2017  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/StateMachine.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/StateMachine.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2017  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/Transition.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/Transition.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2017  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/impl/FsmFactoryImpl.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/impl/FsmFactoryImpl.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2017  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm.impl;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/impl/FsmPackageImpl.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/impl/FsmPackageImpl.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2017  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm.impl;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/util/FsmAdapterFactory.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/util/FsmAdapterFactory.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2017  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm.util;

--- a/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/util/FsmSwitch.java
+++ b/official_samples/LegacyFSM/language_workbench/org.eclipse.gemoc.sample.legacyfsm.xsfsm/src-gen/org/eclipse/gemoc/sample/legacyfsm/xsfsm/xsfsmmt/fsm/util/FsmSwitch.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015, 2017  Inria  and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.sample.legacyfsm.xsfsm.xsfsmmt.fsm.util;

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <repository>
             <id>melange</id>
             <layout>p2</layout>
-            <url>http://melange.inria.fr/updatesite/nightly/update_2017-10-12</url>
+            <url>http://melange.inria.fr/updatesite/nightly/update_2018-01-19/</url>
         </repository>
         <repository>
             <id>Sirius</id>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <repository>
             <id>nebula</id>
             <layout>p2</layout>
-            <url>http://archive.eclipse.org/nebula/Q22016/incubation</url>
+            <url>http://download.eclipse.org/nebula/snapshot/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Use latest version of Melange that  enables the use of new dsl files

additionally, it partially fix  melange issue such as https://github.com/diverse-project/melange/issues/105 (which is actually a problem of thread safety in the manifestchanger ) 

this PR must comes with its counterpart PR https://github.com/eclipse/gemoc-studio-modeldebugging/pull/26 