### PR TITLE
Improve discovery

### DIFF
--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/META-INF/MANIFEST.MF
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/META-INF/MANIFEST.MF
@@ -8,6 +8,14 @@ Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.amalgam.discovery.ui;bundle-version="1.0.0",
+ org.eclipse.equinox.p2.core,
+ org.eclipse.equinox.p2.ui,
+ org.eclipse.equinox.p2.metadata,
+ org.eclipse.equinox.p2.metadata.repository,
+ org.eclipse.equinox.p2.repository,
+ org.eclipse.equinox.p2.engine,
+ org.eclipse.equinox.p2.director,
+ org.eclipse.equinox.p2.operations,
  org.eclipse.core.net;bundle-version="1.2.200"
 Bundle-Activator: org.eclipse.gemoc.gemoc_studio.branding.Activator
 Bundle-ActivationPolicy: lazy

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/DiscoveryWizard.java
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/DiscoveryWizard.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2009 Tasktop Technologies and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Tasktop Technologies - initial API and implementation
+ *      Obeo - adaptation for Amalgamation, EMF based and no Mylyn dependency
+ *******************************************************************************/
+package org.eclipse.gemoc.gemoc_studio.branding.discovery.wizards;
+
+import org.eclipse.amalgam.discovery.ui.common.internal.CommonImages;
+import org.eclipse.amalgam.discovery.ui.common.internal.PrepareInstallProfileJob;
+import org.eclipse.amalgam.discovery.ui.viewer.DiscoveryContentProvider;
+import org.eclipse.jface.wizard.Wizard;
+
+/**
+ * A wizard for performing discovery of connectors and selecting connectors to
+ * install. When finish is pressed, selected connectors are downloaded and
+ * installed.
+ * 
+ * @see PrepareInstallProfileJob
+ * @see ConnectorDiscoveryWizardMainPage
+ * @author David Green
+ */
+public class DiscoveryWizard extends Wizard {
+
+    private DiscoveryWizardMainPage mainPage;
+
+    private boolean showConnectorDescriptorKindFilter = true;
+
+    private boolean showConnectorDescriptorTextFilter = true;
+
+    private DiscoveryContentProvider provider;
+
+    public DiscoveryWizard(DiscoveryContentProvider provider) {
+        this.provider = provider;
+        setWindowTitle(provider.getTitle());
+        setNeedsProgressMonitor(true);
+        setDefaultPageImageDescriptor(CommonImages.BANNER_DISCOVERY);
+    }
+
+    @Override
+    public void addPages() {
+        addPage(mainPage = new DiscoveryWizardMainPage(this.provider));
+    }
+
+    @Override
+    public boolean performFinish() {
+        return Installer.install(mainPage.getInstallableConnectors(), getContainer());
+    }
+
+    /**
+     * indicate if the connector descriptor filters should be shown in the UI.
+     * Changing this setting only has an effect before the UI is presented.
+     */
+    public boolean isShowConnectorDescriptorKindFilter() {
+        return showConnectorDescriptorKindFilter;
+    }
+
+    /**
+     * indicate if the connector descriptor filters should be shown in the UI.
+     * Changing this setting only has an effect before the UI is presented.
+     */
+    public void setShowConnectorDescriptorKindFilter(boolean showConnectorDescriptorKindFilter) {
+        this.showConnectorDescriptorKindFilter = showConnectorDescriptorKindFilter;
+    }
+
+    /**
+     * indicate if a text field should be provided to allow the user to filter
+     * connector descriptors
+     */
+    public boolean isShowConnectorDescriptorTextFilter() {
+        return showConnectorDescriptorTextFilter;
+    }
+
+    /**
+     * indicate if a text field should be provided to allow the user to filter
+     * connector descriptors
+     */
+    public void setShowConnectorDescriptorTextFilter(boolean showConnectorDescriptorTextFilter) {
+        this.showConnectorDescriptorTextFilter = showConnectorDescriptorTextFilter;
+    }
+
+}

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/DiscoveryWizardMainPage.java
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/DiscoveryWizardMainPage.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2009 Tasktop Technologies and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Tasktop Technologies - initial API and implementation
+ *     David Green
+ *     Shawn Minto bug 275513
+ *     Steffen Pingel bug 276012 code review, bug 277191 gradient canvas
+ *      Obeo - adaptation for Amalgamation, EMF based and no Mylyn dependency
+ *******************************************************************************/
+package org.eclipse.gemoc.gemoc_studio.branding.discovery.wizards;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.amalgam.discovery.InstallableComponent;
+import org.eclipse.amalgam.discovery.ui.viewer.DiscoveryContentProvider;
+import org.eclipse.amalgam.discovery.ui.viewer.DiscoveryViewer;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.window.IShellProvider;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+
+/**
+ * The main wizard page that allows users to select connectors that they wish to
+ * install.
+ * 
+ * @author David Green
+ */
+public class DiscoveryWizardMainPage extends WizardPage implements IShellProvider {
+
+    private static final int MINIMUM_HEIGHT = 480;
+
+    private DiscoveryViewer viewer;
+
+    private DiscoveryContentProvider provider;
+
+    public DiscoveryWizardMainPage(DiscoveryContentProvider provider) {
+        super(DiscoveryWizardMainPage.class.getSimpleName());
+        this.provider = provider;
+        setTitle(provider.getTitle());
+        // setImageDescriptor(image);
+        setDescription(provider.getDescription());
+        setPageComplete(false);
+
+    }
+
+    public void createControl(Composite parent) {
+        viewer = new DiscoveryViewer(this, getContainer(), this.provider);
+        viewer.setShowConnectorDescriptorKindFilter(getWizard().isShowConnectorDescriptorKindFilter());
+        viewer.setShowConnectorDescriptorTextFilter(getWizard().isShowConnectorDescriptorTextFilter());
+        viewer.setVerifyUpdateSiteAvailability(true);
+        viewer.setMinimumHeight(MINIMUM_HEIGHT);
+        viewer.addSelectionChangedListener(new ISelectionChangedListener() {
+            public void selectionChanged(SelectionChangedEvent event) {
+                setPageComplete(!viewer.getInstallableConnectors().isEmpty());
+            }
+        });
+        viewer.createControl(parent);
+
+        setControl(viewer.getControl());
+    }
+
+    @Override
+    public DiscoveryWizard getWizard() {
+        return (DiscoveryWizard) super.getWizard();
+    }
+
+    public List<InstallableComponent> getInstallableConnectors() {
+        return viewer.getInstallableConnectors();
+    }
+
+    private void maybeUpdateDiscovery() {
+        if (!getControl().isDisposed() && isCurrentPage()) {
+            viewer.updateDiscovery();
+        }
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        super.setVisible(visible);
+		if (visible) {
+			Display.getCurrent().asyncExec(new Runnable() {
+				public void run() {
+					maybeUpdateDiscovery();
+				}
+			});
+		}
+    }
+
+    public void setModelingComponents(Collection<InstallableComponent> components) {
+
+    }
+
+}

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/Installer.java
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/Installer.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c)  2009 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.gemoc_studio.branding.discovery.wizards;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+
+import org.eclipse.amalgam.discovery.InstallableComponent;
+import org.eclipse.amalgam.discovery.ui.common.internal.DiscoveryUiUtil;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.gemoc.gemoc_studio.branding.Activator;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.operation.IRunnableContext;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Shell;
+
+public class Installer {
+    public static boolean install(Collection<InstallableComponent> descriptors, IRunnableContext context) {
+    	final PrepareInstallProfileJob job = new PrepareInstallProfileJob(descriptors);
+        try {
+            context.run(true, true, job);
+        } catch (InvocationTargetException e) {
+            IStatus status = new Status(IStatus.ERROR, Activator.PLUGIN_ID, NLS.bind(Messages.ConnectorDiscoveryWizard_installProblems, new Object[] { e.getCause().getMessage() }), e.getCause());
+            Activator.getDefault().getLog().log(status);
+            
+            displayStatus(DiscoveryUiUtil.getShell(), Messages.ConnectorDiscoveryWizard_cannotInstall, status, true);
+            return false;
+        } catch (InterruptedException e) {
+            // canceled
+            return false;
+        }
+        return true;
+    }
+    
+    
+    public static void displayStatus(Shell shell, final String title, final IStatus status, boolean showLinkToErrorLog) {
+
+
+        String message = getFullMessage(status);
+        
+        if (showLinkToErrorLog) {
+            message += "  \n see error log";
+        }
+        switch (status.getSeverity()) {
+        case IStatus.CANCEL:
+        case IStatus.INFO:
+        	DiscoveryUiUtil.createDialog(shell, title, message, MessageDialog.INFORMATION).open();
+            break;
+        case IStatus.WARNING:
+        	DiscoveryUiUtil.createDialog(shell, title, message, MessageDialog.WARNING).open();
+            break;
+        case IStatus.ERROR:
+        default:
+        	DiscoveryUiUtil.createDialog(shell, title, message, MessageDialog.ERROR).open();
+            break;
+        }
+
+    }
+    
+	public static String getFullMessage(IStatus status) {
+		if(status.isMultiStatus()) {
+			StringBuilder sb = new StringBuilder();
+			sb.append(status.getMessage());
+			for ( IStatus subStatus : status.getChildren()) {
+				sb.append("\n");
+				sb.append(getFullMessage(subStatus));
+			}
+			return sb.toString();
+		} else {
+			return status.getMessage();
+		}
+	}
+    
+}

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/Messages.java
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/Messages.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2009 Tasktop Technologies and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Tasktop Technologies - initial API and implementation
+ *     Obeo - adaptation for Amalgamation, EMF based and no Mylyn dependency
+ *******************************************************************************/
+
+package org.eclipse.gemoc.gemoc_studio.branding.discovery.wizards;
+
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * @author David Green
+ */
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.gemoc.gemoc_studio.branding.discovery.wizards.messages"; //$NON-NLS-1$
+
+    public static String ConnectorDiscoveryWizardMainPage_filter_tool;
+
+    public static String ConnectorDiscoveryWizardMainPage_filter_standard;
+
+    public static String ConnectorDescriptorToolTip_detailsLink;
+
+    public static String ConnectorDescriptorToolTip_detailsLink_tooltip;
+
+    public static String ConnectorDiscoveryWizard_cannotInstall;
+
+    public static String ConnectorDiscoveryWizard_connectorDiscovery;
+
+    public static String ConnectorDiscoveryWizard_installProblems;
+
+    public static String InstallConnectorsJob_commaSeparator;
+
+    public static String InstallConnectorsJob_connectorsNotAvailable;
+
+    public static String InstallConnectorsJob_profileProblem;
+
+    public static String InstallConnectorsJob_questionProceed;
+
+    public static String InstallConnectorsJob_questionProceed_long;
+
+    public static String InstallConnectorsJob_task_configuring;
+
+    public static String InstallConnectorsJob_unexpectedError_url;
+
+    public static String ConnectorDiscoveryWizardMainPage_clearButton_accessibleListener;
+
+    public static String ConnectorDiscoveryWizardMainPage_clearButton_toolTip;
+
+    public static String ConnectorDiscoveryWizardMainPage_connectorDiscovery;
+
+    public static String ConnectorDiscoveryWizardMainPage_errorTitle;
+
+    public static String ConnectorDiscoveryWizardMainPage_filter_commercial;
+
+    public static String ConnectorDiscoveryWizardMainPage_filter_framework;
+
+    public static String ConnectorDiscoveryWizardMainPage_filter_incubation;
+
+    public static String ConnectorDiscoveryWizardMainPage_filterLabel;
+
+    public static String ConnectorDiscoveryWizardMainPage_message_with_cause;
+
+    public static String ConnectorDiscoveryWizardMainPage_noConnectorsFound;
+
+    public static String ConnectorDiscoveryWizardMainPage_noConnectorsFound_description;
+
+    public static String ConnectorDiscoveryWizardMainPage_noMatchingItems_filteredType;
+
+    public static String ConnectorDiscoveryWizardMainPage_noMatchingItems_noFilter;
+
+    public static String ConnectorDiscoveryWizardMainPage_noMatchingItems_withFilterText;
+
+    public static String ConnectorDiscoveryWizardMainPage_pageDescription;
+
+    public static String ConnectorDiscoveryWizardMainPage_provider_and_license;
+
+    public static String ConnectorDiscoveryWizardMainPage_tooltip_showOverview;
+
+    public static String ConnectorDiscoveryWizardMainPage_unexpectedException;
+
+    public static String ConnectorDiscoveryWizardMainPage_warningMessageConnectorUnavailable;
+
+    public static String ConnectorDiscoveryWizardMainPage_warningTitleConnectorUnavailable;
+
+    public static String PrepareInstallProfileJob_notFoundDescriptorDetail;
+
+    public static String PrepareInstallProfileJob_calculatingRequirements;
+
+    public static String PrepareInstallProfileJob_computeProfileChangeRequestFailed;
+
+    public static String PrepareInstallProfileJob_errorResolvingHostname;
+
+    public static String PrepareInstallProfileJob_ok;
+
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/PrepareInstallProfileJob.java
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/PrepareInstallProfileJob.java
@@ -163,6 +163,7 @@ public class PrepareInstallProfileJob implements IRunnableWithProgress {
 						installableConnectors.size()));
 		
 		if (operationStatus.getSeverity() > IStatus.WARNING) {
+			Activator.getDefault().getLog().log(operationStatus);
 			throw new RuntimeException(getFullMessage(operationStatus));
 		}
 		return installOperation;

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/PrepareInstallProfileJob.java
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/PrepareInstallProfileJob.java
@@ -1,0 +1,458 @@
+/*******************************************************************************
+ * Copyright (c) 2009 Tasktop Technologies and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Tasktop Technologies - initial API and implementation
+ *     Obeo - adaptation for Amalgamation, EMF based and no Mylyn dependency
+ *******************************************************************************/
+package org.eclipse.gemoc.gemoc_studio.branding.discovery.wizards;
+
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.amalgam.discovery.InstallableComponent;
+import org.eclipse.amalgam.discovery.ui.common.internal.DiscoveryUiUtil;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.equinox.internal.p2.ui.IProvHelpContextIds;
+import org.eclipse.equinox.internal.p2.ui.ProvUI;
+import org.eclipse.equinox.internal.p2.ui.dialogs.InstallWizard;
+import org.eclipse.equinox.internal.p2.ui.dialogs.PreselectedIUInstallWizard;
+import org.eclipse.equinox.internal.p2.ui.dialogs.ProvisioningWizardDialog;
+import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.operations.InstallOperation;
+import org.eclipse.equinox.p2.operations.ProvisioningSession;
+import org.eclipse.equinox.p2.operations.RemediationOperation;
+import org.eclipse.equinox.p2.operations.RepositoryTracker;
+import org.eclipse.equinox.p2.query.IQuery;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
+import org.eclipse.equinox.p2.ui.LoadMetadataRepositoryJob;
+import org.eclipse.equinox.p2.ui.ProvisioningUI;
+import org.eclipse.gemoc.gemoc_studio.branding.Activator;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.operation.IRunnableWithProgress;
+import org.eclipse.jface.window.Window;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * A job that configures a p2 {@link #getInstallAction() install action} for
+ * installing one or more {@link ConnectorDescriptor connectors}. The bulk of
+ * the installation work is done by p2; this class just sets up the p2
+ * repository metadata and selects the appropriate features to install. After
+ * running the job the {@link #getInstallAction() install action} must be run to
+ * perform the installation.
+ * 
+ * @author David Green
+ * @author Steffen Pingel
+ */
+@SuppressWarnings("restriction")
+public class PrepareInstallProfileJob implements IRunnableWithProgress {
+
+	private static final String P2_FEATURE_GROUP_SUFFIX = ".feature.group"; //$NON-NLS-1$
+
+	private final List<InstallableComponent> installableConnectors;
+
+	private final ProvisioningUI provisioningUI;
+
+	private Set<URI> repositoryLocations;
+
+	private boolean headless = false;
+
+	public PrepareInstallProfileJob(
+			Collection<InstallableComponent> installableConnectors) {
+		if (installableConnectors == null || installableConnectors.isEmpty()) {
+			throw new IllegalArgumentException();
+		}
+		this.installableConnectors = new ArrayList<InstallableComponent>(
+				installableConnectors);
+		this.provisioningUI = ProvisioningUI.getDefaultUI();
+	}
+
+	public void setHeadlessMode(boolean isHeadless) {
+		this.headless = isHeadless;
+	}
+
+	public void run(IProgressMonitor progressMonitor)
+			throws InvocationTargetException, InterruptedException {
+		try {
+			SubMonitor monitor = SubMonitor.convert(progressMonitor,
+					Messages.InstallConnectorsJob_task_configuring, 100);
+			try {
+				final Collection<IInstallableUnit> ius = computeInstallableUnits(monitor
+						.newChild(50));
+
+				checkCancelled(monitor);
+
+				final InstallOperation installOperation = resolve(
+						monitor.newChild(50), ius,
+						repositoryLocations.toArray(new URI[0]));
+
+				checkCancelled(monitor);
+
+				if (!headless) {
+					Display.getDefault().asyncExec(new Runnable() {
+						public void run() {
+							openInstallWizard(provisioningUI,ius,
+									installOperation);
+						}
+					});
+				}
+			} finally {
+				monitor.done();
+			}
+		} catch (OperationCanceledException e) {
+			throw new InterruptedException();
+		} catch (Exception e) {
+			throw new InvocationTargetException(e);
+		}
+	}
+	
+	private static int openInstallWizard(ProvisioningUI ui,Collection<IInstallableUnit> initialSelections, InstallOperation operation) {		
+		PreselectedIUInstallWizard wizard = new PreselectedIUInstallWizard(ui, operation, initialSelections, null);
+		wizard.setRemediationOperation(null);
+		Shell defaultParentShell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		
+		WizardDialog dialog = new ProvisioningWizardDialog(defaultParentShell, wizard);
+		dialog.create();
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(dialog.getShell(), IProvHelpContextIds.INSTALL_WIZARD);
+		return dialog.open();
+	}
+	
+	private void checkCancelled(IProgressMonitor monitor) {
+		if (monitor.isCanceled()) {
+			throw new OperationCanceledException();
+		}
+	}
+
+	private InstallOperation resolve(IProgressMonitor monitor,
+			final Collection<IInstallableUnit> ius, URI[] repositories)
+			throws CoreException {
+		final InstallOperation installOperation = provisioningUI
+				.getInstallOperation(ius, repositories);
+		IStatus operationStatus = installOperation
+				.resolveModal(new SubProgressMonitor(monitor,
+						installableConnectors.size()));
+		
+		if (operationStatus.getSeverity() > IStatus.WARNING) {
+			throw new RuntimeException(getFullMessage(operationStatus));
+		}
+		return installOperation;
+	}
+
+	public String getFullMessage(IStatus status) {
+		if(status.isMultiStatus()) {
+			StringBuilder sb = new StringBuilder();
+			sb.append(status.getMessage());
+			for ( IStatus subStatus : status.getChildren()) {
+				sb.append("\n"+getFullMessage(subStatus));
+			}
+			return sb.toString();
+		} else {
+			return status.getMessage();
+		}
+	}
+	public Collection<IInstallableUnit> computeInstallableUnits(
+			SubMonitor monitor) throws CoreException {
+		try {
+			monitor.setWorkRemaining(100);
+			// add repository urls and load meta data
+			List<IMetadataRepository> repositories = addRepositories(monitor
+					.newChild(50));
+			final List<IInstallableUnit> installableUnits = queryInstallableUnits(
+					monitor.newChild(50), repositories);
+			removeOldVersions(installableUnits);
+			checkForUnavailable(installableUnits);
+			return installableUnits;
+
+			// MultiStatus status = new MultiStatus(DiscoveryUi.ID_PLUGIN, 0,
+			// Messages.PrepareInstallProfileJob_ok, null);
+			// ius = installableUnits.toArray(new
+			// IInstallableUnit[installableUnits.size()]);
+			// ProfileChangeRequest profileChangeRequest =
+			// InstallAction.computeProfileChangeRequest(ius, profileId,
+			// status, new SubProgressMonitor(monitor,
+			// installableConnectors.size()));
+			// if (status.getSeverity() > IStatus.WARNING) {
+			// throw new CoreException(status);
+			// }
+			// if (profileChangeRequest == null) {
+			// // failed but no indication as to why
+			// throw new CoreException(new Status(IStatus.ERROR,
+			// DiscoveryUi.ID_PLUGIN,
+			// Messages.PrepareInstallProfileJob_computeProfileChangeRequestFailed,
+			// null));
+			// }
+			// PlannerResolutionOperation operation = new
+			// PlannerResolutionOperation(
+			// Messages.PrepareInstallProfileJob_calculatingRequirements,
+			// profileId, profileChangeRequest, null,
+			// status, true);
+			// IStatus operationStatus = operation.execute(new
+			// SubProgressMonitor(monitor, installableConnectors.size()));
+			// if (operationStatus.getSeverity() > IStatus.WARNING) {
+			// throw new CoreException(operationStatus);
+			// }
+			//
+			// plannerResolutionOperation = operation;
+
+		} catch (URISyntaxException e) {
+			// should never happen, since we already validated URLs.
+			throw new CoreException(new Status(IStatus.ERROR,
+					Activator.PLUGIN_ID,
+					Messages.InstallConnectorsJob_unexpectedError_url, e));
+		} catch (MalformedURLException e) {
+			// should never happen, since we already validated URLs.
+			throw new CoreException(new Status(IStatus.ERROR,
+					Activator.PLUGIN_ID,
+					Messages.InstallConnectorsJob_unexpectedError_url, e));
+		} finally {
+			monitor.done();
+		}
+	}
+
+	/**
+	 * Verifies that we found what we were looking for: it's possible that we
+	 * have connector descriptors that are no longer available on their
+	 * respective sites. In that case we must inform the user. Unfortunately
+	 * this is the earliest point at which we can know.
+	 */
+	private void checkForUnavailable(
+			final List<IInstallableUnit> installableUnits) throws CoreException {
+		// at least one selected connector could not be found in a repository
+		Set<String> foundIds = new HashSet<String>();
+		for (IInstallableUnit unit : installableUnits) {
+			String id = unit.getId();
+			if (id.endsWith(P2_FEATURE_GROUP_SUFFIX)) {
+				id = id.substring(0, id.indexOf(P2_FEATURE_GROUP_SUFFIX));
+			}
+			foundIds.add(id);
+		}
+
+		String message = ""; //$NON-NLS-1$
+		String detailedMessage = ""; //$NON-NLS-1$
+		for (InstallableComponent descriptor : installableConnectors) {
+			StringBuilder unavailableIds = null;
+			for (String id : descriptor.getId()) {
+				if (!foundIds.contains(id)) {
+					if (unavailableIds == null) {
+						unavailableIds = new StringBuilder();
+					} else {
+						unavailableIds
+								.append(Messages.InstallConnectorsJob_commaSeparator);
+					}
+					unavailableIds.append(id);
+				}
+			}
+			if (unavailableIds != null) {
+				if (message.length() > 0) {
+					message += Messages.InstallConnectorsJob_commaSeparator;
+				}
+				message += descriptor.getName();
+
+				if (detailedMessage.length() > 0) {
+					detailedMessage += Messages.InstallConnectorsJob_commaSeparator;
+				}
+				detailedMessage += NLS
+						.bind(Messages.PrepareInstallProfileJob_notFoundDescriptorDetail,
+								new Object[] { descriptor.getName(),
+										unavailableIds.toString(),
+										descriptor.getSitesURLS() });
+			}
+		}
+
+		if (message.length() > 0) {
+			// instead of aborting here we ask the user if they wish to proceed
+			// anyways
+			final boolean[] okayToProceed = new boolean[1];
+			final String finalMessage = message;
+
+			if (headless) {
+				throw new RuntimeException(detailedMessage);
+			} else {
+				Display.getDefault().syncExec(new Runnable() {
+					public void run() {
+						okayToProceed[0] = MessageDialog.openQuestion(
+								DiscoveryUiUtil.getShell(),
+								Messages.InstallConnectorsJob_questionProceed,
+								NLS.bind(
+										Messages.InstallConnectorsJob_questionProceed_long,
+										new Object[] { finalMessage }));
+					}
+				});
+				if (!okayToProceed[0]) {
+					throw new CoreException(
+							new Status(
+									IStatus.ERROR,
+									Activator.PLUGIN_ID,
+									NLS.bind(
+											Messages.InstallConnectorsJob_connectorsNotAvailable,
+											detailedMessage), null));
+				}
+			}
+		}
+	}
+
+	/**
+	 * Filters those installable units that have a duplicate in the list with a
+	 * higher version number. it's possible that some repositories will host
+	 * multiple versions of a particular feature. we assume that the user wants
+	 * the highest version.
+	 */
+	private void removeOldVersions(final List<IInstallableUnit> installableUnits) {
+		Map<String, Version> symbolicNameToVersion = new HashMap<String, Version>();
+		for (IInstallableUnit unit : installableUnits) {
+			Version version = symbolicNameToVersion.get(unit.getId());
+			if (version == null || version.compareTo(unit.getVersion()) == -1) {
+				symbolicNameToVersion.put(unit.getId(), unit.getVersion());
+			}
+		}
+		if (symbolicNameToVersion.size() != installableUnits.size()) {
+			for (IInstallableUnit unit : new ArrayList<IInstallableUnit>(
+					installableUnits)) {
+				Version version = symbolicNameToVersion.get(unit.getId());
+				if (!version.equals(unit.getVersion())) {
+					installableUnits.remove(unit);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Perform a query to get the installable units. This causes p2 to determine
+	 * what features are available in each repository. We select installable
+	 * units by matching both the feature id and the repository; it is possible
+	 * though unlikely that the same feature id is available from more than one
+	 * of the selected repositories, and we must ensure that the user gets the
+	 * one that they asked for.
+	 */
+	private List<IInstallableUnit> queryInstallableUnits(SubMonitor monitor,
+			List<IMetadataRepository> repositories) throws URISyntaxException {
+		final List<IInstallableUnit> installableUnits = new ArrayList<IInstallableUnit>();
+
+		monitor.setWorkRemaining(repositories.size());
+		for (final IMetadataRepository repository : repositories) {
+			checkCancelled(monitor);
+			final Set<String> installableUnitIdsThisRepository = getDescriptorIds(repository);
+			IQuery<IInstallableUnit> query = QueryUtil.createMatchQuery( //
+					"id ~= /*.feature.group/ && " + //$NON-NLS-1$
+							"properties['org.eclipse.equinox.p2.type.group'] == true ");//$NON-NLS-1$
+			IQueryResult<IInstallableUnit> result = repository.query(query,
+					monitor.newChild(1));
+			for (Iterator<IInstallableUnit> iter = result.iterator(); iter
+					.hasNext();) {
+				IInstallableUnit iu = iter.next();
+				String id = iu.getId();
+				if (installableUnitIdsThisRepository.contains(id.substring(0,
+						id.indexOf(P2_FEATURE_GROUP_SUFFIX)))) {
+					installableUnits.add(iu);
+				}
+			}
+		}
+		return installableUnits;
+	}
+
+	private List<IMetadataRepository> addRepositories(SubMonitor monitor)
+			throws MalformedURLException, URISyntaxException,
+			ProvisionException {
+		// tell p2 that it's okay to use these repositories
+		ProvisioningSession session = ProvisioningUI.getDefaultUI()
+				.getSession();
+		RepositoryTracker repositoryTracker = ProvisioningUI.getDefaultUI()
+				.getRepositoryTracker();
+		repositoryLocations = new HashSet<URI>();
+		monitor.setWorkRemaining(installableConnectors.size() * 5);
+		for (InstallableComponent descriptor : installableConnectors) {
+			for (String url : descriptor.getSitesURLS()) {
+				addASiteURL(monitor, session, repositoryTracker, url);
+			}
+		}
+
+		// fetch meta-data for these repositories
+		ArrayList<IMetadataRepository> repositories = new ArrayList<IMetadataRepository>();
+		monitor.setWorkRemaining(repositories.size());
+		IMetadataRepositoryManager manager = (IMetadataRepositoryManager) session
+				.getProvisioningAgent().getService(
+						IMetadataRepositoryManager.SERVICE_NAME);
+		for (URI uri : repositoryLocations) {
+			checkCancelled(monitor);
+			IMetadataRepository repository = manager.loadRepository(uri,
+					monitor.newChild(1));
+			repositories.add(repository);
+		}
+		return repositories;
+	}
+
+	private void addASiteURL(SubMonitor monitor, ProvisioningSession session,
+			RepositoryTracker repositoryTracker, String url)
+			throws URISyntaxException, MalformedURLException {
+		URI uri = new URL(url).toURI();
+		if (repositoryLocations.add(uri)) {
+			checkCancelled(monitor);
+			repositoryTracker.addRepository(uri, null, session);
+			// ProvisioningUtil.addMetaDataRepository(url.toURI(), true);
+			// ProvisioningUtil.addArtifactRepository(url.toURI(), true);
+			// ProvisioningUtil.setColocatedRepositoryEnablement(url.toURI(),
+			// true);
+		}
+		monitor.worked(1);
+	}
+
+	private Set<String> getDescriptorIds(final IMetadataRepository repository)
+			throws URISyntaxException {
+		final Set<String> installableUnitIdsThisRepository = new HashSet<String>();
+		// determine all installable units for this repository
+		for (InstallableComponent descriptor : installableConnectors) {
+			try {
+				if (hasThisUpdateSite(repository.getLocation(), descriptor)) {
+					installableUnitIdsThisRepository.addAll(descriptor.getId());
+				}
+
+			} catch (MalformedURLException e) {
+				// will never happen, ignore
+			}
+		}
+		return installableUnitIdsThisRepository;
+	}
+
+	private boolean hasThisUpdateSite(URI location,
+			InstallableComponent descriptor) throws MalformedURLException {
+		boolean found = false;
+		Iterator<String> it = descriptor.getSitesURLS().iterator();
+		while (it.hasNext() && !found) {
+			String url = it.next();
+			if (location.toString().equals(url))
+				found = true;
+		}
+		return found;
+	}
+
+}

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/messages.properties
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/discovery/wizards/messages.properties
@@ -1,0 +1,51 @@
+###############################################################################
+# Copyright (c) 2009 Tasktop Technologies and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#      Tasktop Technologies - initial API and implementation
+###############################################################################
+ConnectorDescriptorToolTip_detailsLink=<a>Learn More</a>
+ConnectorDescriptorToolTip_detailsLink_tooltip=Open {0} in an external browser
+ConnectorDiscoveryWizard_cannotInstall=Cannot complete installation
+ConnectorDiscoveryWizard_connectorDiscovery=Install Components
+ConnectorDiscoveryWizard_installProblems=Problems occurred while performing installation: {0}
+ConnectorDiscoveryWizardMainPage_clearButton_accessibleListener=Clear filter field
+ConnectorDiscoveryWizardMainPage_clearButton_toolTip=Clear
+ConnectorDiscoveryWizardMainPage_connectorDiscovery= Components Discovery 
+ConnectorDiscoveryWizardMainPage_errorTitle=Components Discovery Error
+ConnectorDiscoveryWizardMainPage_filter_commercial=Commercial
+ConnectorDiscoveryWizardMainPage_filter_framework=Framework
+ConnectorDiscoveryWizardMainPage_filter_incubation=Incubation Status
+ConnectorDiscoveryWizardMainPage_filter_standard=Standard Based
+ConnectorDiscoveryWizardMainPage_filter_tool=Tool
+ConnectorDiscoveryWizardMainPage_filterLabel=Find:
+ConnectorDiscoveryWizardMainPage_message_with_cause={0}: {1}
+ConnectorDiscoveryWizardMainPage_noConnectorsFound=No Component Found
+ConnectorDiscoveryWizardMainPage_noConnectorsFound_description=Discovery completed without finding any component.  Please check your Internet connection and try again.
+ConnectorDiscoveryWizardMainPage_noMatchingItems_filteredType=There are no component of the selected type.  Please select another component type or try again later.
+ConnectorDiscoveryWizardMainPage_noMatchingItems_noFilter=Sorry, there are no available component.  Please try again later.
+ConnectorDiscoveryWizardMainPage_noMatchingItems_withFilterText=There are no matching component.  Please <a>clear the filter text</a> or try again later.
+ConnectorDiscoveryWizardMainPage_pageDescription=\
+	Select component to install. Press Finish to proceed with installation.\n\
+	Press the information button to see a detailed overview and a link to more information.
+ConnectorDiscoveryWizardMainPage_provider_and_license=by {0}, {1}
+ConnectorDiscoveryWizardMainPage_tooltip_showOverview=Show Overview
+ConnectorDiscoveryWizardMainPage_unexpectedException=Unexpected exception
+ConnectorDiscoveryWizardMainPage_warningMessageConnectorUnavailable=Sorry, {0} is unavailable.  Please try again later.
+ConnectorDiscoveryWizardMainPage_warningTitleConnectorUnavailable=Component Unavailable
+InstallConnectorsJob_commaSeparator=, 
+InstallConnectorsJob_connectorsNotAvailable=The following components are not available: {0}
+InstallConnectorsJob_profileProblem=Cannot determine p2 profile
+InstallConnectorsJob_questionProceed=Proceed With Installation?
+InstallConnectorsJob_questionProceed_long=The following components are not available: {0}\nProceed with the installation anyways?
+InstallConnectorsJob_task_configuring=Configuring installation selection
+InstallConnectorsJob_unexpectedError_url=Unexpected error handling repository URL
+PrepareInstallProfileJob_notFoundDescriptorDetail={0} (id={1}, site={2})
+PrepareInstallProfileJob_calculatingRequirements=Calculating requirements
+PrepareInstallProfileJob_computeProfileChangeRequestFailed=Cannot compute profile change request
+PrepareInstallProfileJob_errorResolvingHostname=Error resolving hostname {1} for '{0}': please check your Internet connection and try again.
+PrepareInstallProfileJob_ok=OK

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/handlers/GemocPackageDiscovery.java
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/handlers/GemocPackageDiscovery.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import org.eclipse.amalgam.discovery.DiscoveryDefinition;
 import org.eclipse.amalgam.discovery.core.CancellableXMIResourceImpl;
 import org.eclipse.amalgam.discovery.ui.viewer.DiscoveryContentProvider;
-import org.eclipse.amalgam.discovery.ui.wizards.DiscoveryWizard;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -32,6 +31,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.progress.IProgressService;
 import org.eclipse.gemoc.gemoc_studio.branding.Activator;
+import org.eclipse.gemoc.gemoc_studio.branding.discovery.wizards.DiscoveryWizard;
 
 public class GemocPackageDiscovery extends DiscoveryContentProvider {
 


### PR DESCRIPTION
fixes https://github.com/eclipse/gemoc-studio/issues/52
This allows to have a better error reporting in case of installation failure via the discovery.
Due to API restriction, the code is not very nice and duplicates some classes from amalgam.

However a better fix has been provided directly in amalgam (https://git.eclipse.org/r/#/c/118366/ and https://bugs.eclipse.org/bugs/show_bug.cgi?id=531789 )
So this PR will have to be reverted as soon as the gerrit patch has been accepted and deployed in the official eclipse update site.