### PR TITLE
[tests] Workaround to discard webkitgtk error message

### DIFF
--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/XDSMLPerspective_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/XDSMLPerspective_Test.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  *     Inria - initial API and implementation
  *******************************************************************************/
@@ -27,6 +27,7 @@ import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException
 
 /**
  * This class check the content of the XDSML Perspective
@@ -34,13 +35,12 @@ import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences
 @RunWith(SWTBotJunit4ClassRunner)
 @InjectWith(MelangeUiInjectorProvider)
 //@FixMethodOrder(MethodSorters::NAME_ASCENDING)
-public class XDSMLPerspective_Test extends AbstractXtextTests
-{
-	
+public class XDSMLPerspective_Test extends AbstractXtextTests {
+
 	static WorkspaceTestHelper helper = new WorkspaceTestHelper
-	
-	private static SWTWorkbenchBot	bot;
- 
+
+	private static SWTWorkbenchBot bot;
+
 	@BeforeClass
 	def static void beforeClass() throws Exception {
 		bot = new SWTWorkbenchBot()
@@ -49,7 +49,7 @@ public class XDSMLPerspective_Test extends AbstractXtextTests
 		helper.init
 
 	}
-	
+
 	@Before
 	override setUp() {
 		bot.resetWorkbench
@@ -58,44 +58,51 @@ public class XDSMLPerspective_Test extends AbstractXtextTests
 		key.pressShortcut(Keystrokes.ESC);
 		// make sure we are on the correct perspective
 		bot.perspectiveById(XDSMLFrameworkUI.ID_PERSPECTIVE).activate()
-		//val projExplorerBot = bot.viewByTitle("Project Explorer").bot
+	// val projExplorerBot = bot.viewByTitle("Project Explorer").bot
 	}
-	
+
 	@After
 	override tearDown() {
 		// Nothing to do
 	}
-	
+
 	@Test
 	def void test01_FileMenuContent() throws Exception {
 		helper.assertContains("Menu does not contain", "GEMOC Sequential xDSML Project",
-				bot.menu("File").menu("New").menuItems())
+			bot.menu("File").menu("New").menuItems())
 		helper.assertContains("Menu does not contain", "K3 Project", bot.menu("File").menu("New").menuItems())
 		helper.assertContains("Menu does not contain", "Ecore Modeling Project",
-				bot.menu("File").menu("New").menuItems())
+			bot.menu("File").menu("New").menuItems())
 
 	}
+
 	@Test
 	def void test02_toolbarDropDownNewMenuContent() throws Exception {
 		val newMenu = bot.toolbarDropDownButtonWithTooltip("New")
 		newMenu.menuItem("K3 Project").click
 		bot.button("Cancel").click
-		
+
 		newMenu.menuItem("GEMOC Sequential xDSML Project").click
 		bot.button("Cancel").click
-		
+
 		newMenu.menuItem("Ecore Modeling Project").click
+
+		// Workaround to discard the error message that pops when webkitgtk is not installed on the system
+		// "Unknown Mozilla path (MOZILLA_FIVE_HOME not set)"
+		try {
+			bot.button("No").click
+		} catch (WidgetNotFoundException e) {
+		}
+
+		bot.shell("New Ecore Modeling Project").setFocus
 		bot.button("Cancel").click
-		
+
 	}
-	
-	
+
 	@Test
 	def void test03_toolbarContent() throws Exception {
 		bot.toolbarButtonWithTooltip("Install GEMOC Components").click
 		bot.button("Cancel").click
 	}
-	
-	
-	
+
 }


### PR DESCRIPTION
The SWTBot test `test02_toolbarDropDownNewMenuContent` was failing due to an error message appearing because a webkitgtk lib is not installed on the Eclipse CI slave.

This PR simply adds an SWTBot action to discard this error message if it appears, which allows the test to continue and pass.

CI build here (still building at the time of writing) : https://ci.eclipse.org/gemoc/job/gemoc-studio/job/workaround-problem-test-webkitgtk/

Signed-off-by: Erwan Bousse <erwan.bousse@tuwien.ac.at>