### PR TITLE
Upgrade Melange to version 2018-04-11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <repository>
             <id>melange</id>
             <layout>p2</layout>
-            <url>http://melange.inria.fr/updatesite/nightly/update_2018-01-19/</url>
+            <url>http://melange.inria.fr/updatesite/nightly/update_2018-04-11/</url>
         </repository>
         <repository>
             <id>Sirius</id>


### PR DESCRIPTION
It includes https://github.com/diverse-project/melange/pull/114 in order
to better manage generated languages project as Gemoc projects since the project that hosts the .melange file is not supposed to be a Gemoc project.

This PR comes with https://github.com/eclipse/gemoc-studio-modeldebugging/pull/37