### PR TITLE
Use Gren for release note management

### DIFF
--- a/.grenrc.yml
+++ b/.grenrc.yml
@@ -1,0 +1,23 @@
+---
+  dataSource: "prs"
+  prefix: "v"
+  ignoreLabels: 
+    - "duplicate"
+    - "invalid"
+    - "question"
+    - "to do"
+    - "wontfix"
+  ignoreIssuesWith: 
+    - "duplicate"
+    - "invalid"
+    - "question"
+    - "wontfix"
+  "groupBy": {
+        "Enhancements:": ["enhancement"],
+        "Bug Fixes:": ["bug"],
+        "Refactorings": ["refactoring"],
+        "Version upgrades": ["bump"],
+        "Release Engineering": ["releng"]
+  }
+  onlyMilestones: false
+  changelogFilename: "CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+## v3.0.0-rc2 (11/04/2018)
+Release Candidate 2 of the GEMOC Studio 3.0.0.
+
+Corresponding artifacts: 
+- Update site is available: http://download.eclipse.org/gemoc/updates/milestones/3.0.0rc2
+- Eclipse packages: http://download.eclipse.org/gemoc/packages/milestones/3.0.0rc2?d (click on *show directory content*)
+
+It contains the following important changes on this repository (to have a complete view, please also look to the companion release tag on gemoc-studio-modeldebugging https://github.com/eclipse/gemoc-studio-modeldebugging/releases/tag/3.0.0-rc2):
+
+#### Enhancements:
+
+- [**enhancement**][**refactoring**] Change grammar of DSL file  to a grammar similar to Java property file [#40](https://github.com/eclipse/gemoc-studio/pull/40)
+
+#### Bug Fixes:
+
+- [**bug**] Improve Discovery error reporting in case of incorrect configuration [#53](https://github.com/eclipse/gemoc-studio/pull/53)
+- [**bug**] ensures to run changeStyle in an UI thread when printing large messages on console [#44](https://github.com/eclipse/gemoc-studio/pull/44)
+
+#### Version upgrades
+
+- [**bump**] Upgrade to Melange 2018-01-19 [#48](https://github.com/eclipse/gemoc-studio/pull/48)
+- [**bump**][**releng**] Update tycho to version 1.0.0 [#34](https://github.com/eclipse/gemoc-studio/pull/34)
+
+#### Release Engineering
+
+- [**releng**] Releng improvements [#50](https://github.com/eclipse/gemoc-studio/pull/50)
+
+---
+
+## v3.0.0rc2 (11/04/2018)
+*No changelog for this release.*
+
+---
+
+## 3.0.0rc1 (07/12/2017)
+release candidate 1 of the Studio 3.0.0.
+
+Corresponding artifacts: 
+- Update site is available: http://download.eclipse.org/gemoc/updates/milestones/3.0.0rc1
+- Eclipse packages: http://download.eclipse.org/gemoc/packages/milestones/3.0.0rc1?d (click on *show directory content*)
+
+It contains the following important changes on this repository (to have a complete view, please also look to the companion release tag on gemoc-studio-modeldebugging https://github.com/eclipse/gemoc-studio-modeldebugging/releases/tag/3.0.0-rc1):
+- naming now follows eclipse conventions (org.eclipse.gemoc.xxx) (https://github.com/eclipse/gemoc-studio/pull/16)
+- Studio is based on Eclipse Oxygen (https://github.com/eclipse/gemoc-studio/pull/23 https://github.com/eclipse/gemoc-studio/pull/27 https://github.com/eclipse/gemoc-studio/pull/28 https://github.com/eclipse/gemoc-studio/pull/29 )
+- improved test suites (https://github.com/eclipse/gemoc-studio/pull/35 https://github.com/eclipse/gemoc-studio/pull/36)
+- introduction of DSL file support ( https://github.com/eclipse/gemoc-studio/pull/13 https://github.com/eclipse/gemoc-studio/pull/39)
+- continous intregration on http://ci.eclipse.org/gemoc (https://github.com/eclipse/gemoc-studio/pull/1 https://github.com/eclipse/gemoc-studio/pull/2 https://github.com/eclipse/gemoc-studio/pull/3 https://github.com/eclipse/gemoc-studio/pull/5 https://github.com/eclipse/gemoc-studio/pull/6)
+- and some bug fixes (https://github.com/eclipse/gemoc-studio/pull/4 https://github.com/eclipse/gemoc-studio/pull/9)
+
+---
+
+## 2.4.0 (20/10/2017)
+*No changelog for this release.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 # Changelog
 
 ## v3.0.0-rc2 (11/04/2018)
-Release Candidate 2 of the GEMOC Studio 3.0.0.
-
-Corresponding artifacts: 
-- Update site is available: http://download.eclipse.org/gemoc/updates/milestones/3.0.0rc2
-- Eclipse packages: http://download.eclipse.org/gemoc/packages/milestones/3.0.0rc2?d (click on *show directory content*)
-
-It contains the following important changes on this repository (to have a complete view, please also look to the companion release tag on gemoc-studio-modeldebugging https://github.com/eclipse/gemoc-studio-modeldebugging/releases/tag/3.0.0-rc2):
 
 #### Enhancements:
 
@@ -29,27 +22,42 @@ It contains the following important changes on this repository (to have a comple
 
 ---
 
-## v3.0.0rc2 (11/04/2018)
-*No changelog for this release.*
+## v3.0.0-rc1 (07/12/2017)
+
+#### Enhancements:
+
+- [**enhancement**] Improve messagingsystem usability [#38](https://github.com/eclipse/gemoc-studio/pull/38)
+- [**enhancement**] Improve xdsml test suites [#35](https://github.com/eclipse/gemoc-studio/pull/35)
+- [**enhancement**] Add grammar and editor for DSL file [#13](https://github.com/eclipse/gemoc-studio/pull/13)
+- [**enhancement**] Improve option management of GEMOC project wizard templates [#9](https://github.com/eclipse/gemoc-studio/pull/9)
+
+#### Bug Fixes:
+
+- [**bug**] Fix predefined update sites [#29](https://github.com/eclipse/gemoc-studio/pull/29)
+- [**bug**] Remove last references to Eclipse Neon [#28](https://github.com/eclipse/gemoc-studio/pull/28)
+- [**bug**] Make more robust retry loop in MessagingSystemManager [#5](https://github.com/eclipse/gemoc-studio/pull/5)
+
+#### Refactorings
+
+- [**refactoring**] Change keyword 'semantic' to semantics' in dslfile [#39](https://github.com/eclipse/gemoc-studio/pull/39)
+- [**refactoring**] Mass rename org.gemoc -> org.eclipse.gemoc [#16](https://github.com/eclipse/gemoc-studio/pull/16)
+
+#### Version upgrades
+
+- [**bump**] Upgrade to latest k3 version [#33](https://github.com/eclipse/gemoc-studio/pull/33)
+- [**bump**] Upgrade to Eclipse Oxygen [#27](https://github.com/eclipse/gemoc-studio/pull/27)
+- [**bump**] Migrate to Eclipse oxygen [#23](https://github.com/eclipse/gemoc-studio/pull/23)
+- [**bump**] Upgrade version of the studio to 2.4.0 [#7](https://github.com/eclipse/gemoc-studio/pull/7)
+
+#### Release Engineering
+
+- [**releng**] Remove backlog tests from CI build [#36](https://github.com/eclipse/gemoc-studio/pull/36)
 
 ---
 
-## 3.0.0rc1 (07/12/2017)
-release candidate 1 of the Studio 3.0.0.
+## v2.4.0 (20/10/2017)
 
-Corresponding artifacts: 
-- Update site is available: http://download.eclipse.org/gemoc/updates/milestones/3.0.0rc1
-- Eclipse packages: http://download.eclipse.org/gemoc/packages/milestones/3.0.0rc1?d (click on *show directory content*)
+#### Release Engineering
 
-It contains the following important changes on this repository (to have a complete view, please also look to the companion release tag on gemoc-studio-modeldebugging https://github.com/eclipse/gemoc-studio-modeldebugging/releases/tag/3.0.0-rc1):
-- naming now follows eclipse conventions (org.eclipse.gemoc.xxx) (https://github.com/eclipse/gemoc-studio/pull/16)
-- Studio is based on Eclipse Oxygen (https://github.com/eclipse/gemoc-studio/pull/23 https://github.com/eclipse/gemoc-studio/pull/27 https://github.com/eclipse/gemoc-studio/pull/28 https://github.com/eclipse/gemoc-studio/pull/29 )
-- improved test suites (https://github.com/eclipse/gemoc-studio/pull/35 https://github.com/eclipse/gemoc-studio/pull/36)
-- introduction of DSL file support ( https://github.com/eclipse/gemoc-studio/pull/13 https://github.com/eclipse/gemoc-studio/pull/39)
-- continous intregration on http://ci.eclipse.org/gemoc (https://github.com/eclipse/gemoc-studio/pull/1 https://github.com/eclipse/gemoc-studio/pull/2 https://github.com/eclipse/gemoc-studio/pull/3 https://github.com/eclipse/gemoc-studio/pull/5 https://github.com/eclipse/gemoc-studio/pull/6)
-- and some bug fixes (https://github.com/eclipse/gemoc-studio/pull/4 https://github.com/eclipse/gemoc-studio/pull/9)
-
----
-
-## 2.4.0 (20/10/2017)
-*No changelog for this release.*
+- [**releng**] Add Studio variant identification in splashscreen and about box [#6](https://github.com/eclipse/gemoc-studio/pull/6)
+- [**releng**] Add local full build support [#2](https://github.com/eclipse/gemoc-studio/pull/2)


### PR DESCRIPTION
Use GREN (https://github.com/github-tools/github-release-notes) for generating release notes.

We use Pull Requests as input.
This implies that:
- we must tag every pull request in order to include it in the note
- we must follow some convention for the title of the pull request (see https://github.com/github-tools/github-release-notes)
  1.  Start the subject line with a verb (e.g. Change header styles)
  1.   Use the imperative mood in the subject line (e.g. Fix, not Fixed or Fixes header styles)
  1.  Limit the subject line to about 50 characters
  1.  Do not end the subject line with a period
  1.  Separate subject from body with a blank line
  1.  Wrap the body at 72 characters
  1.  Use the body to explain what and why not how

Currently, the command has to be launched manually by one of the official commiter.

Concretly this PR:
- archives grenrc.yml config file in order to simplify release note production
- adds a CHANGELOG.md in the repository
see issue #24