### PR TITLE
Fixes eclipse help navigation table of content

### DIFF
--- a/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/dev/ContributingDocumentation.asciidoc
+++ b/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/dev/ContributingDocumentation.asciidoc
@@ -43,3 +43,10 @@ The document is organized as follow:
 ====
 In order to ease modifications, every files must start with a footnote allowing to retrieve the source file in the git repositories. 
 ====
+
+
+[TIP]
+====
+To edit the documentation we recommand the use of http://plantuml.com/eclipse,eclipse[plantuml eclipse plugin]   and https://github.com/de-jcup/eclipse-asciidoctor-editor[eclipse asciidoc editor] .
+You can install them in an Eclipse using either the market place or the following update site: https://ascii-uml.github.io/eclipse/
+====

--- a/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/introduction_headContent.asciidoc
+++ b/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/introduction_headContent.asciidoc
@@ -25,12 +25,12 @@ image::images/introduction/GemocWorkbenchesGlobalPicture.png["Gemoc Workbenches 
 
 In this document:
 
- * items or roles relative to the Language Workbench are identified with the following icon : image:images/icons/IconeGemocLanguage_32.png[width=48, height=48]
- * items or roles relative to the Modeling Workbench are identified with the following icon : image:images/icons/IconeGemocModel_32.png[width=48, height=48]
+ * items or roles relative to the Language Workbench are identified with the following icon : image:images/icons/IconeGemocLanguage_32.png[width=32, height=32]
+ * items or roles relative to the Modeling Workbench are identified with the following icon : image:images/icons/IconeGemocModel_32.png[width=32, height=32]
 
 [NOTE]
 ====
-The latest version of this document is available online from http://gemoc.github.io/gemoc-studio/
+The latest version of this document is available online from http://gemoc.org/studio_documentations.html
 ====
 
 === Language Workbench overview image:images/icons/IconeGemocLanguage_16.png[width=16, height=16, role=right]

--- a/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/plugin.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/plugin.xml
@@ -20,15 +20,7 @@
             primary="true">
       </toc>
       <toc
-            file="eclipse_help/guide/eclipse/toc.xml"
-            primary="false">
-      </toc>
-      <toc
-            file="eclipse_help/tutorial_markedgraph/eclipse/toc.xml"
-            primary="false">
-      </toc>
-      <toc
-            file="eclipse_help/tutorial_sigpml/eclipse/toc.xml"
+            file="eclipse_help/master/toc.xml"
             primary="false">
       </toc>
    </extension>

--- a/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/toc.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/toc.xml
@@ -12,10 +12,8 @@
         Inria - initial API and implementation
  -->
 
-<toc label="GEMOC Studio Documentation" topic="eclipse_help/html/toc.html">
- <topic href="eclipse_help/master/master.html" label="GEMOC Studio">
-    <link toc="eclipse_help/master/toc.xml"/>
- </topic>
+<toc label="GEMOC Studio Documentation" topic="eclipse_help/master/master.html">
+   <link toc="eclipse_help/master/toc.xml"/>
  <topic label="GEMOC Studio Extra Tutorials &amp; Examples">
     <topic label="GEMOC Extra Tutorials">
        <anchor id="GEMOC.tutorials"/>


### PR DESCRIPTION
Fixes eclipse help navigation table of content

also improve some information about how to build the documentation

fixes https://github.com/eclipse/gemoc-studio/issues/86