### PR TITLE
Add pre-release version of ecoretools epackage registration

### DIFF
--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
@@ -50,6 +50,7 @@ http://www.eclipse.org/legal/epl-v10.html
       <import feature="org.eclipse.ecf.filetransfer.httpclient4.feature.source" version="3.13.7" match="greaterOrEqual"/>
       <import feature="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.source" version="1.1.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.ecf.filetransfer.ssl.feature.source" version="1.1.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.ecoretools.registration.feature" version="3.3.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.query.sdk" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.compare" version="2.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.compare.source" version="2.0.0" match="greaterOrEqual"/>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
             <layout>p2</layout>
             <url>http://download.eclipse.org/nebula/snapshot/</url>
         </repository>
+        <repository>
+            <id>diverse-commons</id>
+            <layout>p2</layout>
+            <url>http://www.kermeta.org/diverse-commons/updates/latest</url>
+        </repository>
     </repositories>
 
 


### PR DESCRIPTION
As the code submitted to Ecoretools project is very long to be accepted by its commiter team (https://bugs.eclipse.org/bugs/show_bug.cgi?id=537295),

this PR deploys a pre-release version of EPackage registration.

This version has been compiled from https://github.com/diverse-project/tools and deployed to http://www.kermeta.org/diverse-commons/updates/latest/
(sources are the same as the
one proposed to https://bugs.eclipse.org/bugs/show_bug.cgi?id=537295 )

This PR contributes to https://github.com/eclipse/gemoc-studio/issues/14