### PR TITLE
Fix docker file for pomless builds

### DIFF
--- a/dev_support/full_compilation/README.asciidoc
+++ b/dev_support/full_compilation/README.asciidoc
@@ -83,4 +83,20 @@ docker-compose run gemoc_full_compilation system_test_only
 
 The _Dockerfile_ defines a docker image based on ubuntu 16.04 with maven, oracle java8, xvfb, and graphviz. It embeds an *entrypoint.sh* script that calls the maven command.
 The _docker-compose.yml_ will mount the folder containing all gemoc repositories (ie. the place where you've done `git clone`) 
-It also mounts a *cache-m2* folder in order to speed up the compilation.  
+It also mounts a *cache-m2* folder in order to speed up the compilation.
+
+The docker-compose command is more or less equivalent to:
+[source,bourne]
+----
+docker build -t gemoc-full-compilation .
+docker run -v $PWD/../../../..:/root/src -v $PWD/cache-m2:/root/.m2 gemoc-full-compilation
+----
+
+Then you'll have to manually prune unused containers after usage.
+
+If for some reason you wish to access it interactively you can use the following command:
+[source,bourne]
+----
+docker run --entrypoint "/bin/bash" -ti  -v $PWD/../../../..:/root/src -v $PWD/cache-m2:/root/.m2 gemoc-full-compilation
+----
+   

--- a/dev_support/full_compilation/docker/entrypoint.sh
+++ b/dev_support/full_compilation/docker/entrypoint.sh
@@ -5,6 +5,8 @@ echo arguments seen: $1
 Xvfb :99 &
 export DISPLAY=:99
 
+cd /root/src/gemoc-studio
+
 if [ -z "$1" ]
 then
 	echo "---------- compile full gemoc studio -----------"


### PR DESCRIPTION
Changes working directory in order to correctly enable pomless builds

fixes https://github.com/eclipse/gemoc-studio/issues/133

small improvement in the documentation about how to use the docker image

Signed-off-by: Didier Vojtisek <didier.vojtisek@inria.fr>