### PR TITLE
Remove 32 bit versions of the studio

### DIFF
--- a/gemoc_studio/pom.xml
+++ b/gemoc_studio/pom.xml
@@ -102,7 +102,7 @@
                             <ws>gtk</ws>
                             <arch>x86_64</arch>
                         </environment>
-                        <environment>
+                       <!--  <environment>
                             <os>linux</os>
                             <ws>gtk</ws>
                             <arch>x86</arch>
@@ -111,7 +111,7 @@
                             <os>win32</os>
                             <ws>win32</ws>
                             <arch>x86</arch>
-                        </environment>
+                        </environment> -->
                         <environment>
                             <os>win32</os>
                             <ws>win32</ws>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.product/src/main/filtered-resources/products/index.html
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.product/src/main/filtered-resources/products/index.html
@@ -199,10 +199,8 @@
           </ul>
           <p><b>Build date: ${timestamp}</b></p>
           <div id='dirlist' style='display:inline;'><img src='https://dev.eclipse.org/small_icons/places/folder.png'><a href='/gemoc/packages/nightly/../?d'> ..</a><br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-linux.gtk.x86.zip'> gemoc_studio-linux.gtk.x86.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-linux.gtk.x86_64.zip'> gemoc_studio-linux.gtk.x86_64.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-macosx.cocoa.x86_64.zip'> gemoc_studio-macosx.cocoa.x86_64.zip</a> <br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-win32.win32.x86.zip'> gemoc_studio-win32.win32.x86.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-win32.win32.x86_64.zip'> gemoc_studio-win32.win32.x86_64.zip</a><br />
 </div><script language='javascript' src='/errors/js.js'></script>
           <h2>Other useful links</h2>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.product/src/main/filtered-resources/products/index.html
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.product/src/main/filtered-resources/products/index.html
@@ -200,15 +200,11 @@
           <p>The headless version is a limited version that offers only command line interface.</p>
           <p><b>Build date: ${timestamp}</b></p>
           <div id='dirlist' style='display:inline;'><img src='https://dev.eclipse.org/small_icons/places/folder.png'><a href='/gemoc/packages/nightly/../?d'> ..</a><br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-linux.gtk.x86.zip'> gemoc_studio-linux.gtk.x86.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-linux.gtk.x86_64.zip'> gemoc_studio-linux.gtk.x86_64.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-macosx.cocoa.x86_64.zip'> gemoc_studio-macosx.cocoa.x86_64.zip</a> <br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-win32.win32.x86.zip'> gemoc_studio-win32.win32.x86.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-win32.win32.x86_64.zip'> gemoc_studio-win32.win32.x86_64.zip</a><br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-linux.gtk.x86.zip'> gemoc_studio_headless_engine_runner-linux.gtk.x86.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-linux.gtk.x86_64.zip'> gemoc_studio_headless_engine_runner-linux.gtk.x86_64.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-macosx.cocoa.x86_64.zip'> gemoc_studio_headless_engine_runner-macosx.cocoa.x86_64.zip</a> <br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-win32.win32.x86.zip'> gemoc_studio_headless_engine_runner-win32.win32.x86.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-win32.win32.x86_64.zip'> gemoc_studio_headless_engine_runner-win32.win32.x86_64.zip</a><br />
 </div><script language='javascript' src='/errors/js.js'></script>
           <h2>Other useful links</h2>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 							<ws>gtk</ws>
 							<arch>x86_64</arch>
 						</environment>
-						<environment>
+					<!-- 	<environment>
 							<os>linux</os>
 							<ws>gtk</ws>
 							<arch>x86</arch>
@@ -150,7 +150,7 @@
 							<os>win32</os>
 							<ws>win32</ws>
 							<arch>x86</arch>
-						</environment>
+						</environment> -->
 						<environment>
 							<os>win32</os>
 							<ws>win32</ws>


### PR DESCRIPTION
Nowadays, 32-bit versions of the studio are rarely used.
This PR remove these versions from the default distribution.
This saves some build time and disk space on the CI

(fixes https://github.com/eclipse/gemoc-studio/issues/114)