### PR TITLE
Add concurrent engine to studio

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,18 @@ pipeline {
 	         				checkout gemocstudiomodeldebuggingScm
 	         			}
 				}
+				dir('gemoc-studio-moccml') {
+    					script {
+	         				def gemocstudiomoccmlScm = resolveScm source: [$class: 'GitSCMSource', credentialsId: '', id: '_', remote: 'https://github.com/eclipse/gemoc-studio-moccml.git', traits: [[$class: 'BranchDiscoveryTrait'], [$class: 'LocalBranchTrait']]], targets: [BRANCH_NAME, 'master']
+	         				checkout gemocstudiomoccmlScm
+	         			}
+				}
+				dir('gemoc-studio-execution-moccml') {
+    					script {
+	         				def gemocstudioexecutionmoccmlScm = resolveScm source: [$class: 'GitSCMSource', credentialsId: '', id: '_', remote: 'https://github.com/eclipse/gemoc-studio-execution-moccml.git', traits: [[$class: 'BranchDiscoveryTrait'], [$class: 'LocalBranchTrait']]], targets: [BRANCH_NAME, 'master']
+	         				checkout gemocstudioexecutionmoccmlScm
+	         			}
+				}
 			    echo 'Content of the workspace'
 				sh "ls"
 				sh "chmod 777 ./gemoc-studio/dev_support/jenkins/showGitBranches.sh"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+-------------
+This repository is part of a serie of repositories related to [GEMOC Studio](http://eclipse.org/gemoc) :
+- https://github.com/eclipse/gemoc-studio
+- https://github.com/eclipse/gemoc-studio-modeldebugging
+- https://github.com/eclipse/gemoc-studio-execution-ale
+- https://github.com/eclipse/gemoc-studio-execution-java
+- https://github.com/eclipse/gemoc-studio-execution-moccml
+- https://github.com/eclipse/gemoc-studio-moccml
+-------------
+
 Gemoc Studio
 ============
 

--- a/dev_support/full_compilation/pom.xml
+++ b/dev_support/full_compilation/pom.xml
@@ -16,6 +16,8 @@
 		<module>../../../gemoc-studio/gemoc_studio</module>
 		<module>../../../gemoc-studio-modeldebugging</module>
 		<module>../../../gemoc-studio-execution-ale</module>
+		<module>../../../gemoc-studio-moccml</module>
+		<!-- <module>../../../gemoc-studio-execution-moccml</module>-->
 	</modules>
 
 </project>

--- a/dev_support/full_compilation/pom.xml
+++ b/dev_support/full_compilation/pom.xml
@@ -17,7 +17,7 @@
 		<module>../../../gemoc-studio-modeldebugging</module>
 		<module>../../../gemoc-studio-execution-ale</module>
 		<module>../../../gemoc-studio-moccml</module>
-		<!-- <module>../../../gemoc-studio-execution-moccml</module>-->
+		<module>../../../gemoc-studio-execution-moccml</module>
 	</modules>
 
 </project>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
@@ -45,6 +45,9 @@ http://www.eclipse.org/legal/epl-v10.html
       <import feature="fr.inria.diverse.melange.sdk" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.ecoretools.ale.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.gemoc.ale.interpreted.engine.feature" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="fr.inria.aoste.timesquare.feature" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.gemoc.moccml.mapping.feature" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.gemoc.moccml.constraint.feature" version="0.0.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
@@ -48,6 +48,7 @@ http://www.eclipse.org/legal/epl-v10.html
       <import feature="fr.inria.aoste.timesquare.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.gemoc.moccml.mapping.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.gemoc.moccml.constraint.feature" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature" version="0.0.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
             <url>http://melange.inria.fr/updatesite/nightly/update_2019-01-25/</url>
         </repository>
         <repository>
+            <id>timesquare</id>
+            <layout>p2</layout>
+            <url>http://www.i3s.unice.fr/~deantoni/photon/</url>
+<!--             <url>http://timesquare.inria.fr/update_site/photon</url> -->
+        </repository>
+        <repository>
             <id>Sirius</id>
             <layout>p2</layout>
             <url>http://download.eclipse.org/sirius/updates/releases/6.0.1/photon</url>


### PR DESCRIPTION
This PR adds the build support and deployment of the concurrent engine in the studio.

cf. https://github.com/eclipse/gemoc-studio/issues/146
It comes with several PR in other repositories:
* https://github.com/eclipse/gemoc-studio-moccml/pull/1
* https://github.com/eclipse/gemoc-studio-execution-moccml/pull/1
* https://github.com/eclipse/gemoc-studio-execution-ale/pull/8
* https://github.com/eclipse/gemoc-studio-modeldebugging/pull/98