### PR TITLE
Re-enable plantuml figures in documentation

### DIFF
--- a/docs/org.eclipse.gemoc.studio.doc/pom.xml
+++ b/docs/org.eclipse.gemoc.studio.doc/pom.xml
@@ -51,7 +51,10 @@
 
     <build>
         <plugins>
-        
+        	<!-- warning the order is important see https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html section default lifecycle -->
+        	<!--  must be done in the following order: asciidoctor-maven-plugin, plantuml-maven-plugin, docbkx-maven-plugin, replacer -->
+        	<!--  becareful to the ones in the profiles -->
+        	<!-- you can use mvn fr.jcgay.maven.plugins:buildplan-maven-plugin:list-phase cf. https://stackoverflow.com/questions/41493359/visualize-all-maven-phases-goals-profiles-and-plugins to check the order -->
             <!-- Generate a docbook xml file from the asciidoc files -->
              <plugin>
                 <groupId>org.asciidoctor</groupId>
@@ -60,7 +63,7 @@
                 <executions>
                     <execution>
                         <id>output-docbook</id>
-                        <phase>generate-resources</phase>
+                        <phase>process-sources</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>
@@ -381,7 +384,7 @@
 						    <version>2.0</version>                                       
 						    <executions>                                                 
 						        <execution>
-					            <phase>generate-resources</phase>
+					            <phase>process-sources</phase>
 					            <goals>
 					                <goal>execute</goal>
 					            </goals>
@@ -420,7 +423,7 @@
 						<executions>
 							<execution>
 								<id>output-plantuml</id>
-								<phase>generate-resources</phase>
+								<phase>process-sources</phase>
 								<goals>
 									<goal>generate</goal>
 								</goals>

--- a/docs/org.eclipse.gemoc.studio.doc/pom.xml
+++ b/docs/org.eclipse.gemoc.studio.doc/pom.xml
@@ -177,44 +177,6 @@
                  </executions>
             </plugin>
             
-            <!-- collect images from included document parts -->
-            <!--  TODO -->
-            
-            
-            <!-- generate the images from plantUMl -->
-		 	<plugin>
-				<groupId>com.github.jeluard</groupId>
-				<artifactId>plantuml-maven-plugin</artifactId>
-				<version>1.2</version>
-				<executions>
-					<execution>
-						<id>output-plantuml</id>
-						<phase>generate-resources</phase>
-						<goals>
-							<goal>generate</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<outputInSourceDirectory>true</outputInSourceDirectory>
-					<verbose>true</verbose>
-					<sourceFiles>
-						<directory>${basedir}</directory>
-						<includes>
-							<include>target/generated-docbook/**/*.plantuml</include>
-						</includes>
-					</sourceFiles>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>net.sourceforge.plantuml</groupId>
-						<artifactId>plantuml</artifactId>
-						<version>8059</version>
-					</dependency>
-				</dependencies>
-			</plugin>  
-
-
 			<!-- docbook generation part -->
 			<plugin>				
 				<groupId>com.agilejava.docbkx</groupId>
@@ -402,4 +364,88 @@
 
         </plugins>
     </build>
+    <profiles>
+    	<profile>
+    		<!-- if  the build is slow due to https://github.com/eclipse/gemoc-studio/issues/152 -->
+    		<!-- you can disable this profile in the launcher using the following "!plantuml"  or "-P !plantuml" --> 
+    		<!-- or you may run this maven using the docker environment -->
+    		<id>plantuml</id>
+    		<activation>
+    			<activeByDefault>true</activeByDefault>
+    		</activation>
+    		<build>
+    			<plugins>
+    				<plugin>
+					    <groupId>org.codehaus.gmaven</groupId>                       
+						    <artifactId>groovy-maven-plugin</artifactId>                 
+						    <version>2.0</version>                                       
+						    <executions>                                                 
+						        <execution>
+					            <phase>generate-resources</phase>
+					            <goals>
+					                <goal>execute</goal>
+					            </goals>
+					            <configuration>                                      
+					                <source> 
+					                	def pbWithGraphviwVersionversion = false  
+					                	try { 
+					                		def proc = "dot -V".execute();
+					                		def outputStream = new StringBuffer();
+											proc.waitForProcessOutput(outputStream, outputStream);
+											if(outputStream.toString().contains("2.39") || outputStream.toString().contains("2.40")) {
+												pbWithGraphviwVersionversion = true
+												System.err.println(outputStream.toString());
+											} else {
+												println(outputStream.toString());
+											}
+										} catch(Exception e) {
+										}     
+										if(!pbWithGraphviwVersionversion){                                
+						                    log.info('Graphiz check: {}', 'if  the build is slow due to https://github.com/eclipse/gemoc-studio/issues/152')
+						                    log.info('Graphiz check: {}', 'you can disable the "plantuml" profile (using "-P !plantuml") or you may run this maven using the docker environment')
+						                } else {
+						                    log.warn('Graphiz check: {}', 'if  the build is slow due to https://github.com/eclipse/gemoc-studio/issues/152')
+						                    log.warn('Graphiz check: {}', 'you can disable the "plantuml" profile (using "-P !plantuml") or you may run this maven using the docker environment')
+						                }
+					                </source>                                        
+					            </configuration> 
+					        </execution>
+					    </executions>
+					</plugin>
+    				<!-- generate the images from plantUMl -->
+				 	<plugin>
+						<groupId>com.github.jeluard</groupId>
+						<artifactId>plantuml-maven-plugin</artifactId>
+						<version>1.2</version>
+						<executions>
+							<execution>
+								<id>output-plantuml</id>
+								<phase>generate-resources</phase>
+								<goals>
+									<goal>generate</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<outputInSourceDirectory>true</outputInSourceDirectory>
+							<verbose>true</verbose>
+							<sourceFiles>
+								<directory>${basedir}</directory>
+								<includes>
+									<include>target/generated-docbook/**/*.plantuml</include>
+								</includes>
+							</sourceFiles>
+						</configuration>
+						<dependencies>
+							<dependency>
+								<groupId>net.sourceforge.plantuml</groupId>
+								<artifactId>plantuml</artifactId>
+								<version>8059</version>
+							</dependency>
+						</dependencies>
+					</plugin>
+    			</plugins>
+    		</build>
+    	</profile>
+    </profiles>
 </project>

--- a/docs/org.eclipse.gemoc.studio.doc/pom.xml
+++ b/docs/org.eclipse.gemoc.studio.doc/pom.xml
@@ -182,7 +182,7 @@
             
             
             <!-- generate the images from plantUMl -->
-		<!-- 	<plugin>
+		 	<plugin>
 				<groupId>com.github.jeluard</groupId>
 				<artifactId>plantuml-maven-plugin</artifactId>
 				<version>1.2</version>
@@ -213,7 +213,7 @@
 					</dependency>
 				</dependencies>
 			</plugin>  
--->
+
 
 			<!-- docbook generation part -->
 			<plugin>				


### PR DESCRIPTION
This PR re-enables the plantuml image generation.

Additionally, it provides a new profile (`plantuml`) that one can deactivate in order to speed up his build. (using the option `-P !plantuml`)
A message is shown in the log in order to remind this option. 
This message is shown as a warning if it detects a version 2.39 or 2.40 of Graphviz