### PR TITLE
Use url for discovery that is unique for gemoc 3.1.x

### DIFF
--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/handlers/GemocPackageDiscovery.java
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/src/main/java/org/eclipse/gemoc/gemoc_studio/branding/handlers/GemocPackageDiscovery.java
@@ -35,7 +35,7 @@ import org.eclipse.gemoc.gemoc_studio.branding.discovery.wizards.DiscoveryWizard
 
 public class GemocPackageDiscovery extends DiscoveryContentProvider {
 
-	private static final String CATALOG_URI = "http://gemoc.org/discovery/catalog.xmi";
+	private static final String CATALOG_URI = "http://gemoc.org/discovery/gemoc_3.1.x/catalog.xmi";
 
 	@Override
 	public DiscoveryDefinition load(final IProgressMonitor monitor)


### PR DESCRIPTION
I've created a new URL on GEMOC site for discovery that is unique for the Studio 3.1.x (ie. current master and next official release this summer)

The url is http://gemoc.org/discovery/gemoc_3.1.x/catalog.xmi
Its content is also available on the following web page : http://gemoc.org/discovery/gemoc_3.1.x/catalog.html

Note : the goal is to make sure that all the content provided will remain stable (ie. contain update site specific to this version (no "lastest build" that may fail in the future)

contributes to https://github.com/eclipse/gemoc-studio/issues/120

Signed-off-by: Didier Vojtisek <didier.vojtisek@inria.fr>