### PR TITLE
Do not wait for discovery update site availability check in tests

### DIFF
--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/XDSMLPerspective_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/XDSMLPerspective_Test.xtend
@@ -111,6 +111,9 @@ public class XDSMLPerspective_Test extends AbstractXtextTests {
 		bot.toolbarButtonWithTooltip("Install GEMOC Components").click
 		bot.sleep(8000);
 		bot.shell("GEMOC Components Discovery").setFocus
+		try {
+			bot.toolbarButtonWithTooltip("Cancel Operation").click(); // the update site check may be very long -> do not wait
+		} catch (WidgetNotFoundException e) {}
 		bot.button("Cancel").click
 	}
 


### PR DESCRIPTION
Removes some flaky test situations

contributes to https://github.com/eclipse/gemoc-studio/issues/123

Signed-off-by: Didier Vojtisek <didier.vojtisek@inria.fr>