### PR TITLE
Bump GEMOC Studio to 3.2.0

### DIFF
--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/META-INF/MANIFEST.MF
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio
 Bundle-SymbolicName: org.eclipse.gemoc.gemoc_studio.branding;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: GEMOC
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/META-INF/MANIFEST.MF
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio Headless
 Bundle-SymbolicName: org.eclipse.gemoc.gemoc_studio.headless;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: Eclipse
 Automatic-Module-Name: org.eclipse.gemoc.headless
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 	<artifactId>org.eclipse.gemoc.gemoc_studio.headless</artifactId>

--- a/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/META-INF/MANIFEST.MF
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Documentation
 Bundle-SymbolicName: org.eclipse.gemoc.language_workbench.documentation; singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.language_workbench.documentation.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/gemoc_studio/pom.xml
+++ b/gemoc_studio/pom.xml
@@ -15,7 +15,7 @@
     <name>GEMOC Studio root build</name>
     <groupId>org.eclipse.gemoc.gemoc_studio</groupId>
     <artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 	<parent>
 		<groupId>org.eclipse.gemoc</groupId>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.gemoc_studio.additions.feature"
       label="GEMOC Studio Additional Features"
-      version="3.1.0.qualifier"
+      version="3.2.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.gemoc.gemoc_studio</groupId>
         <artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.gemoc_studio.branding.feature"
       label="GEMOC Studio Main Features"
-      version="3.1.0.qualifier"
+      version="3.2.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gemoc.gemoc_studio.branding"
       image="gemocstudio32.png">

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.gemoc.gemoc_studio</groupId>
         <artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.gemoc_studio.headless.feature"
       label="GEMOC Studio Headless Features"
-      version="3.1.0.qualifier"
+      version="3.2.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.eclipse.gemoc.gemoc_studio</groupId>
         <artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.product/gemoc_studio_headless.product
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.product/gemoc_studio_headless.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="GEMOC Headless EngineRunner" uid="gemoc_studio_headless_engine_runner" id="org.eclipse.gemoc.gemoc_studio.headless.GemocStudioHeadless" application="org.eclipse.gemoc.gemoc_studio.headless.EngineRunner" version="3.1.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="GEMOC Headless EngineRunner" uid="gemoc_studio_headless_engine_runner" id="org.eclipse.gemoc.gemoc_studio.headless.GemocStudioHeadless" application="org.eclipse.gemoc.gemoc_studio.headless.EngineRunner" version="3.2.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <text>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.product/gemoc_studio_headless.product
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.product/gemoc_studio_headless.product
@@ -58,7 +58,7 @@ org.eclipse.gemoc.gemoc_studio.headless.GemocStudioHeadless
    </plugins>
 
    <features>
-      <feature id="org.eclipse.gemoc.gemoc_studio.headless.feature" version="3.1.0.qualifier"/>
+      <feature id="org.eclipse.gemoc.gemoc_studio.headless.feature"/>
    </features>
 
    <configurations>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.product/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.product/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.product/gemoc_studio.product
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.product/gemoc_studio.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Gemoc Studio" uid="gemoc_studio" id="org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio" application="org.eclipse.ui.ide.workbench" version="3.1.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Gemoc Studio" uid="gemoc_studio" id="org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio" application="org.eclipse.ui.ide.workbench" version="3.2.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <image path="/org.eclipse.gemoc.gemoc_studio.branding/images/GemocStudioAboutImage.png"/>
@@ -52,13 +52,11 @@ openFile
       </win>
    </launcher>
 
-
    <vm>
       <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</linux>
       <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</macos>
       <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</windows>
    </vm>
-
 
    <plugins>
    </plugins>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.product/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.product/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
@@ -93,13 +93,13 @@
    <feature url="features/org.eclipse.gemoc.gexpressions.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.gexpressions.feature" version="3.0.0.qualifier">
       <category name="GEMOC_3_gemoc-studio_Components"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.gemoc_studio.additions.feature_3.1.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.additions.feature" version="3.1.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.gemoc_studio.additions.feature_3.2.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.additions.feature" version="3.2.0.qualifier">
       <category name="GEMOC_1_AllInOne"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.gemoc_studio.branding.feature_3.1.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.branding.feature" version="3.1.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.gemoc_studio.branding.feature_3.2.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.branding.feature" version="3.2.0.qualifier">
       <category name="GEMOC_1_AllInOne"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.gemoc_studio.headless.feature_3.1.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.headless.feature" version="3.1.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.gemoc_studio.headless.feature_3.2.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.headless.feature" version="3.2.0.qualifier">
       <category name="GEMOC_1_AllInOne"/>
    </feature>
    <feature url="features/org.eclipse.gemoc.execution.moccml.feature_2.3.0.qualifier.jar" id="org.eclipse.gemoc.execution.moccml.feature" version="2.3.0.qualifier">

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.gemoc.gemoc_studio</groupId>
         <artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.backlog/META-INF/MANIFEST.MF
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.backlog/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio Test System Backlog
 Bundle-SymbolicName: org.eclipse.gemoc.studio.tests.system.backlog
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui;bundle-version="2.4.0",
  org.junit;bundle-version="4.12.0",

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.backlog/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.backlog/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.studio.tests.system.backlog</artifactId>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/META-INF/MANIFEST.MF
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio Test System
 Bundle-SymbolicName: org.eclipse.gemoc.studio.tests.system.lwb
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui;bundle-version="3.1.0",
  org.junit;bundle-version="4.12.0",

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.studio.tests.system.lwb</artifactId>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/META-INF/MANIFEST.MF
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio Test System
 Bundle-SymbolicName: org.eclipse.gemoc.studio.tests.system.mwb
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui;bundle-version="3.1.0",
  org.junit;bundle-version="4.12.0",

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.studio.tests.system.mwb</artifactId>

--- a/official_samples/K3FSM/language_workbench/pom.xml
+++ b/official_samples/K3FSM/language_workbench/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
     	<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-    	<version>3.1.0-SNAPSHOT</version>
+    	<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../../../gemoc_studio</relativePath>
 	</parent>
 	


### PR DESCRIPTION
As the official GEMOC Studio 3.1.0 has been released, this PR increases the version of the GEMOC Studio product to 3.2.0.

This prepares the next milestone (that will move its Eclipse  base from Eclipse Photon.1 to Eclipse June 2019) and makes sure that every nightly build is clearly newer than the official 3.1.0.