### PR TITLE
Stop ALE engine on error

### DIFF
--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
@@ -3,7 +3,7 @@
    <feature url="features/org.eclipse.gemoc.commons.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.commons.feature" version="3.0.0.qualifier">
       <category name="GEMOC_3_gemoc-studio_Components"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.ale.interpreted.engine.feature_0.0.1.qualifier.jar" id="org.eclipse.gemoc.ale.interpreted.engine.feature" version="0.0.1.qualifier">
+   <feature url="features/org.eclipse.gemoc.ale.interpreted.engine.feature_1.0.1.qualifier.jar" id="org.eclipse.gemoc.ale.interpreted.engine.feature" version="1.0.1.qualifier">
       <category name="GEMOC_5_Execution ALE_Components"/>
    </feature>
    <feature url="features/org.eclipse.gemoc.moccml.constraint.ccsl.solver.extension.automata.feature_0.1.1.qualifier.jar" id="org.eclipse.gemoc.moccml.constraint.ccsl.solver.extension.automata.feature" version="0.1.1.qualifier">

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
@@ -120,7 +120,7 @@
    <feature url="features/org.eclipse.gemoc.moccml.feature.source_2.3.0.qualifier.jar" id="org.eclipse.gemoc.moccml.feature.source" version="2.3.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.ale.interpreted.engine.feature_0.0.1.qualifier.jar" id="org.eclipse.gemoc.ale.interpreted.engine.feature" version="0.0.1.qualifier">
+   <feature url="features/org.eclipse.gemoc.ale.interpreted.engine.feature_1.0.1.qualifier.jar" id="org.eclipse.gemoc.ale.interpreted.engine.feature" version="1.0.1.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
    <category-def name="GEMOC_1_AllInOne" label="GEMOC all in one">

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         </repository>
 		<repository>
 			<id>ale</id>
-			<url>http://www.kermeta.org/ale-lang/updates/2019-06-24</url>
+			<url>http://www.kermeta.org/ale-lang/updates/2019-08-07</url>
 			<layout>p2</layout>
 		</repository>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         </repository>
 		<repository>
 			<id>ale</id>
-			<url>http://www.kermeta.org/ale-lang/updates/2019-08-07</url>
+			<url>http://www.kermeta.org/ale-lang/updates/2019-08-08</url>
 			<layout>p2</layout>
 		</repository>
         <repository>


### PR DESCRIPTION
This PR integrates the fix of https://github.com/gemoc/ale-lang/issues/38 . Ie. ALE Engine was not stopping the engine in case of unexpected execution error.

It bumps ALE version to the latest available and includes some additions in ALE GEMOC Engine.

This PR comes with the following PR: https://github.com/eclipse/gemoc-studio-execution-ale/pull/21