### PR TITLE
Remove event manager from feature.xml

### DIFF
--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
@@ -96,7 +96,6 @@ http://www.eclipse.org/legal/epl-v10.html
       <import plugin="org.eclipse.gemoc.trace.gemoc.api"/>
       <import plugin="org.eclipse.gemoc.trace.commons.model"/>
       <import plugin="org.eclipse.gemoc.executionframework.event.model"/>
-      <import plugin="org.eclipse.gemoc.executionframework.event.manager"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
This pull request removes the old event manager from the studio and goes with [this pull request](https://github.com/eclipse/gemoc-studio-modeldebugging/pull/119)

Signed-off-by: d-leroy <dorian.leroy@tuwien.ac.at>