### PR TITLE
Improved docker image for local build

### DIFF
--- a/dev_support/full_compilation/README.asciidoc
+++ b/dev_support/full_compilation/README.asciidoc
@@ -26,6 +26,10 @@ First checkout the git repositories :
 ----
 git clone  https://github.com/eclipse/gemoc-studio
 git clone  https://github.com/eclipse/gemoc-studio-modeldebugging
+git clone  https://github.com/eclipse/gemoc-studio-execution-moccml
+git clone  https://github.com/eclipse/gemoc-studio-moccml
+git clone  https://github.com/eclipse/gemoc-studio-execution-ale
+git clone  https://github.com/eclipse/gemoc-studio-execution-java
 ----
 
 Note: the repositories must keep their names (Ie. do not change the destination folder name) as the maven pom file expects to find them at specific locations.
@@ -64,12 +68,38 @@ The build also assemble complementary results:
 
 If you have trouble to reproduce a bug in the CI or want to make sure that the CI will pass, you can run the maven build in a docker that mimic the CI environment.
 
+
+===== build image
+
 To do a full build using docker: go to the docker folder (*/gemoc-studio/dev_support/full_compilation/docker*), then call the command
 
 [source,bourne]
 ----
 docker-compose down && docker-compose up
 ----
+ or
+ 
+[source,bourne]
+----
+docker build -t "gemoc/gemoc-full-compilation:latest" .
+---- 
+
+Changes commited in master branch are automatically built and deployed on https://cloud.docker.com/u/dvojtise/repository/docker/dvojtise/gemoc-full-compilation
+
+
+===== Manual launch
+A standard full build is done using the command:
+[source,bourne]
+----
+docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 gemoc/gemoc-full-compilation:latest ./build_gemoc.sh
+---- 
+
+where
+ 
+- $PWD/../../../.. points to the root containing all gemoc sources
+- --user 1000  makes sure to use your user uid (use `id -u` or `echo $UID`to get yours user uid if this isn't 1000) 
+
+
 
 
 Once the full compilation has been done at least once (ie. and filled the m2 cache), you can run the system test only using the command
@@ -81,8 +111,8 @@ docker-compose run gemoc_full_compilation system_test_only
 Or you can run a full build but including only the linux variant using:
 [source,bourne]
 ----
-docker-compose run gemoc_full_compilation linux
-----
+docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 gemoc/gemoc-full-compilation:latest ./build_gemoc.sh linux
+---- 
 or
 [source,bourne]
 ----
@@ -98,8 +128,8 @@ It also mounts a *cache-m2* folder in order to speed up the compilation.
 The docker-compose command is more or less equivalent to:
 [source,bourne]
 ----
-docker build -t gemoc-full-compilation .
-docker run -v $PWD/../../../..:/root/src -v $PWD/cache-m2:/root/.m2 gemoc-full-compilation
+docker build -t gemoc/gemoc-full-compilation:latest .
+docker run -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 gemoc/gemoc-full-compilation:latest
 ----
 
 Then you'll have to manually prune unused containers after usage.
@@ -107,6 +137,6 @@ Then you'll have to manually prune unused containers after usage.
 If for some reason you wish to access it interactively you can use the following command:
 [source,bourne]
 ----
-docker run --entrypoint "/bin/bash" -ti  -v $PWD/../../../..:/root/src -v $PWD/cache-m2:/root/.m2 gemoc-full-compilation
+docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 gemoc/gemoc-full-compilation:latest /bin/bash
 ----
    

--- a/dev_support/full_compilation/README.asciidoc
+++ b/dev_support/full_compilation/README.asciidoc
@@ -84,7 +84,8 @@ docker-compose down && docker-compose up
 docker build -t "gemoc/gemoc-full-compilation:latest" .
 ---- 
 
-Changes commited in master branch are automatically built and deployed on https://cloud.docker.com/u/dvojtise/repository/docker/dvojtise/gemoc-full-compilation
+Changes commited in master branch are automatically built and deployed on docker hub: https://hub.docker.com/r/gemoc/gemoc-full-compilation
+
 
 
 ===== Manual launch

--- a/dev_support/full_compilation/docker/Dockerfile
+++ b/dev_support/full_compilation/docker/Dockerfile
@@ -1,9 +1,107 @@
-FROM ubuntu:xenial
-RUN apt-get update ; \
-	apt-get install -y software-properties-common python-software-properties xvfb maven graphviz libswt-gtk-3-jni libswt-gtk-3-java;\ 
-	add-apt-repository ppa:webupd8team/java ; \
-	apt-get update ; \
-	echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-	apt-get install -y oracle-java8-installer
-COPY entrypoint.sh .
-ENTRYPOINT ["bash", "./entrypoint.sh"]
+###############################################################
+# Image content overview:
+# - ubuntu 16.04
+# - graphviz
+# - openjdk8, openfx, maven 3.6.0
+# - Xvfb
+# - helper build script for gemoc
+# user id support (for correct ownership of produced files)
+# the docker file is greatly inspired from images at https://github.com/eclipse-cbi/dockerfiles
+###############################################################
+# Rationale:
+# main goal : be able to be usable both in jenkins (on jenkins.eclipse.org new infrastructure) and locally by developpers
+# version selection: 
+# - due to bug in recent version of graphviz we must stick to an older version (cf. https://forum.plantuml.net/5425/relation-long-with-graphviz-using-labels-relations-namespace)
+#   the quickest workaround was to use an older version of ubuntu that has graphviz 2.39.x
+# - use of Xvfb instead of vnc (unlike images from  https://github.com/eclipse-cbi/dockerfiles)
+#		this is because ubuntu 16 use tighvnc instead of tigervnc and tighvnc doesn't support the passwordFile option)
+# - openjdk8 + openjfx : due to recent change in oracle java distribution license
+###############################################################
+
+
+FROM ubuntu:16.04
+
+### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
+COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint
+RUN chmod u+x /usr/local/bin/uid_entrypoint && \
+    chgrp 0 /usr/local/bin/uid_entrypoint && \
+    chmod g=u /usr/local/bin/uid_entrypoint /etc/passwd
+ENTRYPOINT [ "uid_entrypoint" ]
+
+#ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	libgtk-3-0=3.18.* \
+	language-pack-en-base \
+	metacity \
+	x11-xserver-utils \
+	libgl1-mesa-dri \
+	xfonts-base \
+	xfonts-scalable \
+	xfonts-100dpi \
+	xfonts-75dpi \
+	fonts-liberation \
+	fonts-freefont-ttf \
+	fonts-dejavu \
+	fonts-dejavu-core \
+	fonts-dejavu-extra
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	graphviz \
+	xvfb 
+
+RUN apt-get install -y  --no-install-recommends \
+	openjdk-8-jdk \
+	openjfx \
+	maven
+
+RUN apt-get install -y  --no-install-recommends \	
+	dbus
+	 
+# added in an attempt to capture a video of the x display while running UI tests
+# cf. https://malinowski.dev/recording-headless-selenium-tests-to-mp4.html
+RUN apt-get install -y \
+	ffmpeg \
+	tmux
+
+# some cleanup
+RUN rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/jenkins
+
+# avoid "library appears to be incorrectly set up; failed to read machine uuid: UUID file '/etc/machine-id' should contain a hex string of length 32" when launching x 
+# cf http://www.torkwrench.com/2011/12/16/d-bus-library-appears-to-be-incorrectly-set-up-failed-to-read-machine-uuid-failed-to-open-varlibdbusmachine-id/ and https://github.com/activatedgeek/docker-videostack/issues/1
+RUN dbus-uuidgen > /var/lib/dbus/machine-id
+RUN mkdir -p ${HOME}/.cache && \
+	chmod 1777 ${HOME}/.cache
+# explicitly set locale
+ENV LANG=en_US.UTF-8
+
+# avoid _XSERVTransmkdir: ERROR: euid != 0,directory /tmp/.X11-unix will not be created.
+RUN mkdir /tmp/.X11-unix && \
+	chmod 1777 /tmp/.X11-unix && \
+	chown root /tmp/.X11-unix/
+# probably not required during image build
+RUN Xvfb :99 &
+ENV DISPLAY :99
+
+
+
+# additionnal helper build scripts
+COPY scripts/build_gemoc.sh ${HOME}/
+RUN chmod a+x ${HOME}/build_gemoc.sh
+
+
+# switch to default user
+USER 10001
+WORKDIR ${HOME}
+
+#RUN useradd -u 1000 -ms /bin/bash ci
+#RUN useradd -r -u 1000 -g ci ci
+
+ 
+
+#USER ci
+
+#ENTRYPOINT ["bash", "./entrypoint.sh"]
+

--- a/dev_support/full_compilation/docker/docker-compose.yml
+++ b/dev_support/full_compilation/docker/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3'
 services:
   gemoc_full_compilation:
-    image: "gemoc-full-compilation:latest"
+    image: "gemoc/gemoc-full-compilation:latest"
     build: "."
     volumes:
-      - "./cache-m2:/root/.m2"
-      - "../../../..:/root/src"
+      - "./cache-m2:/home/jenkins/.m2"
+      - "../../../..:/home/jenkins/src"
       

--- a/dev_support/full_compilation/docker/scripts/build_gemoc.sh
+++ b/dev_support/full_compilation/docker/scripts/build_gemoc.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+echo arguments seen: $1
+
+Xvfb :99 &
+export DISPLAY=:99
+
+#$HOME/.vnc/xstartup.sh
+
+cd $HOME/src/gemoc-studio/dev_support/full_compilation/
+
+pwd
+
+if [ -z "$1" ]
+then
+	echo "---------- compile full gemoc studio (clean verify) -----------"
+	mvn clean verify --errors  --show-version
+else
+	case $1 in
+	"full") 
+		echo "-------- compile full gemoc studio (and install in .m2) --------"
+		mvn clean install --errors  --show-version;;
+	"linux") 
+		echo "-------- compile gemoc studio for linux only in online (install in .m2) --------"
+		mvn -P test_linux clean install --errors  --show-version;;
+	"linux_no_system_test") 
+		echo "-------- compile gemoc studio for linux only no system tests, online, install in .m2 --------"
+		mvn -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb    clean install --errors  --show-version;;	
+    "linux_no_system_test_offline") 
+		echo "-------- compile gemoc studio for linux only no system tests, offline, install in .m2 --------"
+		mvn -o -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb  clean install --errors  --show-version;;	
+	"linux_offline") 
+		echo "-------- compile gemoc studio for linux only (offline) (install in .m2) --------"
+		mvn -o -P test_linux clean install --errors  --show-version;;
+	"linux_system_test_only") 
+		echo "-------- running system tests only ------------"
+		mvn -P test_linux --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb verify --errors  --show-version;;
+	*)		
+		echo "command $1 not recognized, possible arguments: linux_system_test_only, linux_no_system_test, linux_no_system_test_offline, full, linux_offline" ;;
+	esac
+fi
+

--- a/dev_support/full_compilation/docker/scripts/uid_entrypoint
+++ b/dev_support/full_compilation/docker/scripts/uid_entrypoint
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+: "${USERNAME:="default"}"
+
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USERNAME}:x:$(id -u):0:${USERNAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+exec "$@"


### PR DESCRIPTION
This PR contributes a new docker image allowing to build the full studio including the UI tests.

- Running the `mvn verify`  command locally may lead to some issues: for example, the UI tests will interact with the user display and make them fail if the user continues to work on her computer while running the tests.

This docker image provides a script that launches an Xvfb x server that frees the user display.

Additionally, it makes sure to compile using a jdk8 and the correct version of plantuml (which is buggy on recent Linux distribution cf. https://forum.plantuml.net/5425/relation-long-with-graphviz-using-labels-relations-namespace)

The readme provides some instructions about how to use this image for various needs.

A ready-to-use version of this image is available on docker hub: https://hub.docker.com/r/gemoc/gemoc-full-compilation

Note: the image doesn't provide oracle java8 because recent changes in the oracle licence forbid to distribute it.





