### PR TITLE
autosrc: set java compliance to 1.8

### DIFF
--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.jdt.autosrcfolder/META-INF/MANIFEST.MF
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.jdt.autosrcfolder/META-INF/MANIFEST.MF
@@ -8,3 +8,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.14.0",
  org.eclipse.jdt.core;bundle-version="3.14.0"
 Automatic-Module-Name: org.eclipse.gemoc.srcfolderhelper
 Bundle-Name: AutoSrcFolder
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
One line addition to the new autosrc feature to set the Java compliance to 1.8, otherwise this error can happen when opening the autosrc preference page while running the studio with java 1.8:

>Unable to create the selected preference page.
>org/eclipse/gemoc/commons/eclipse/jdt/autosrcfolder/ui/WorkbenchPreferencePage has been compiled by a more recent version of the Java Runtime (class file version 53.0), this version of the Java Runtime only recognizes class file versions up to 52.0
