### PR TITLE
Use general extension point + nature and builder refactoring

### DIFF
--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.jdt/src/org/eclipse/gemoc/commons/eclipse/jdt/JavaProject.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.jdt/src/org/eclipse/gemoc/commons/eclipse/jdt/JavaProject.java
@@ -17,9 +17,13 @@ import java.io.InputStream;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.gemoc.commons.eclipse.core.resources.IProjectUtils;
 
 public class JavaProject 
@@ -65,6 +69,34 @@ public class JavaProject
 				if (stream != null)
 					stream.close();				
 			}
+	}
+	
+	/**
+	 * Add the folder as a java source folder (ie. update the classpath)
+	 * @param project
+	 * @param folder
+	 * @throws JavaModelException
+	 */
+	public static void addSourceFolder(IProject project, String folder) throws JavaModelException{
+		IJavaProject javaProject = JavaCore.create(project);
+		IClasspathEntry[] entries = javaProject.getRawClasspath();
+		IClasspathEntry[] newEntries = new IClasspathEntry[entries.length + 1];
+		System.arraycopy(entries, 0, newEntries, 0, entries.length);
+
+		IPath srcPath= javaProject.getPath().append(folder);
+		IClasspathEntry srcEntry= JavaCore.newSourceEntry(srcPath, null);
+		
+		boolean entryfound = false;
+		for (IClasspathEntry cpe : entries) {
+			if (cpe.equals(srcEntry)){
+				entryfound = true;
+			}
+		}
+		
+		if (! entryfound) {
+			newEntries[entries.length] = JavaCore.newSourceEntry(srcEntry.getPath());
+			javaProject.setRawClasspath(newEntries, null);
+		}
 	}
 
 }

--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse/src/org/eclipse/gemoc/commons/eclipse/core/resources/IProjectUtils.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse/src/org/eclipse/gemoc/commons/eclipse/core/resources/IProjectUtils.java
@@ -13,8 +13,8 @@ package org.eclipse.gemoc.commons.eclipse.core.resources;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -176,7 +176,7 @@ public class IProjectUtils {
 	public static void removeNature(IProject project, String natureId) throws CoreException 
 	{
 		IProjectDescription description = project.getDescription();
-		List<String> natures = Arrays.asList(description.getNatureIds());
+		ArrayList<String> natures = new ArrayList<String>(Arrays.asList(description.getNatureIds()));
 		natures.remove(natureId);
 		String[] newNatures = natures.toArray(new String[natures.size()]);
 		description.setNatureIds(newNatures);

--- a/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/userguide/lw_CreateGEMOCProject_headContent.asciidoc
+++ b/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/userguide/lw_CreateGEMOCProject_headContent.asciidoc
@@ -35,7 +35,7 @@ It is available in the menu _Window > Open Perspective > Other_.
 This perspective eases the creation of a new xDSML project.
 In the menu _File > New_, you have direct access to
 
-* GEMOC Sequential xDSML Project
+* GEMOC Java xDSML Project
 * GEMOC Concurrent xDSML Project
 
 image::images/userguide/workbench/language/newProject.png[New xDSML project,1000]

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
@@ -141,13 +141,6 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.gemoc.execution.sequential.javaxdsml.api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="javax.annotation"
          download-size="0"
          install-size="0"

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/XDSMLPerspective_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/XDSMLPerspective_Test.xtend
@@ -75,7 +75,7 @@ public class XDSMLPerspective_Test extends AbstractXtextTests {
 
 	@Test
 	def void test01_FileMenuContent() throws Exception {
-		helper.assertContains("Menu does not contain", "GEMOC Sequential xDSML Project",
+		helper.assertContains("Menu does not contain", "GEMOC Java xDSML Project",
 			bot.menu("File").menu("New").menuItems())
 		helper.assertContains("Menu does not contain", "K3 Project", bot.menu("File").menu("New").menuItems())
 		helper.assertContains("Menu does not contain", "Ecore Modeling Project",
@@ -89,7 +89,7 @@ public class XDSMLPerspective_Test extends AbstractXtextTests {
 		newMenu.menuItem("K3 Project").click
 		bot.button("Cancel").click
 
-		newMenu.menuItem("GEMOC Sequential xDSML Project").click
+		newMenu.menuItem("GEMOC Java xDSML Project").click
 		bot.button("Cancel").click
 		
 		newMenu.menuItem("Ecore Modeling Project").click

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateMelangeBasedSingleSequentialLanguageFromOfficialFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateMelangeBasedSingleSequentialLanguageFromOfficialFSM_Test.xtend
@@ -104,7 +104,7 @@ class CreateMelangeBasedSingleSequentialLanguageFromOfficialFSM_Test extends Abs
 	@Test
 	def void test01_OpenXDSMLPerspective() throws Exception {
 		bot.perspectiveById(XDSMLFrameworkUI.ID_PERSPECTIVE).activate()
-		helper.assertContains("Menu does not contain", "GEMOC Sequential xDSML Project",
+		helper.assertContains("Menu does not contain", "GEMOC Java xDSML Project",
 				bot.menu("File").menu("New").menuItems())
 
 	}

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSequentialLanguageFromOfficialK3FSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSequentialLanguageFromOfficialK3FSM_Test.xtend
@@ -109,7 +109,7 @@ public class CreateSequentialLanguageFromOfficialK3FSM_Test extends AbstractXtex
 	@Test
 	def void test01_OpenXDSMLPerspective() throws Exception {
 		bot.perspectiveById(XDSMLFrameworkUI.ID_PERSPECTIVE).activate()
-		helper.assertContains("Menu does not contain", "GEMOC Sequential xDSML Project",
+		helper.assertContains("Menu does not contain", "GEMOC Java xDSML Project",
 			bot.menu("File").menu("New").menuItems())
 
 	}
@@ -118,7 +118,7 @@ public class CreateSequentialLanguageFromOfficialK3FSM_Test extends AbstractXtex
 	def void test02_CreateSequentialLanguageProject() {
 
 		IResourcesSetupUtil::reallyWaitForAutoBuild
-		bot.menu("File").menu("New").menu("GEMOC Sequential xDSML Project").click();
+		bot.menu("File").menu("New").menu("GEMOC Java xDSML Project").click();
 		bot.text().setText(CreateSequentialLanguageFromOfficialK3FSM_Test.XDSML_PROJECT_NAME);
 		bot.button("Next >").click();
 

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateSingleSequentialLanguageFromOfficialFSM_Test.xtend
@@ -106,7 +106,7 @@ class CreateSingleSequentialLanguageFromOfficialFSM_Test extends AbstractXtextTe
 	@Test
 	def void test01_OpenXDSMLPerspective() throws Exception {
 		bot.perspectiveById(XDSMLFrameworkUI.ID_PERSPECTIVE).activate()
-		helper.assertContains("Menu does not contain", "GEMOC Sequential xDSML Project",
+		helper.assertContains("Menu does not contain", "GEMOC Java xDSML Project",
 				bot.menu("File").menu("New").menuItems())
 
 	}
@@ -115,7 +115,7 @@ class CreateSingleSequentialLanguageFromOfficialFSM_Test extends AbstractXtextTe
 	def void test02_CreateSequentialLanguageProject() {
 		
 		IResourcesSetupUtil::reallyWaitForAutoBuild
-		bot.menu("File").menu("New").menu("GEMOC Sequential xDSML Project").click();
+		bot.menu("File").menu("New").menu("GEMOC Java xDSML Project").click();
 		bot.text().setText(PROJECT_NAME);
 		bot.button("Next >").click();
 		

--- a/official_samples/K3FSM/docs/K3FSM.asciidoc
+++ b/official_samples/K3FSM/docs/K3FSM.asciidoc
@@ -95,7 +95,7 @@ NOTE: You may apply some of these steps in a different order. This is only an ex
 ==== Create the Language project
 
 * Open the xDSML perspective
-* Create a GEMOC Sequential xDSML Project named "org.eclipse.gemoc.example.k3fsm.xdsml"( Menu _File -> New -> GEMOC Sequential xDSML Project_) then _Next_ and select _Simple Sequential K3 language project_ -> Finish
+* Create a GEMOC Java xDSML Project named "org.eclipse.gemoc.example.k3fsm.xdsml"( Menu _File -> New -> GEMOC Java xDSML Project_) then _Next_ and select _Simple Sequential K3 language project_ -> Finish
 
 ==== Create the Domain concepts
 

--- a/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/.project
+++ b/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/.project
@@ -26,12 +26,13 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.GemocSequentialLanguageBuilder</name>
+			<name>org.eclipse.gemoc.xdsmlframework.ide.ui.GemocLanguageProjectBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.gemoc.xdsmlframework.ide.ui.GemocLanguageProjectNature</nature>
 		<nature>org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.GemocSequentialLanguageNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>

--- a/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/META-INF/MANIFEST.MF
+++ b/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/META-INF/MANIFEST.MF
@@ -15,8 +15,8 @@ Require-Bundle: org.eclipse.xtend.lib;bundle-version="2.7.0";visibility:="privat
  fr.inria.diverse.melange.resource;bundle-version="0.1.0";visibility:="reexport",
  fr.inria.diverse.melange.adapters;bundle-version="0.1.0";visibility:="reexport",
  fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="0.0.0";visibility:="reexport",
- org.eclipse.gemoc.xdsmlframework.api;bundle-version="0.0.0";visibility:="reexport",
- org.eclipse.gemoc.executionframework.engine;bundle-version="0.0.0";visibility:="reexport",
+ org.eclipse.gemoc.xdsmlframework.api;bundle-version="4.0.0";visibility:="reexport",
+ org.eclipse.gemoc.executionframework.engine;bundle-version="4.0.0";visibility:="reexport",
  org.eclipse.gemoc.executionframework.extensions.sirius;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.gemoc.example.k3fsm;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.example.k3fsm.k3dsa;bundle-version="1.0.0"

--- a/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/META-INF/MANIFEST.MF
+++ b/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/META-INF/MANIFEST.MF
@@ -16,7 +16,6 @@ Require-Bundle: org.eclipse.xtend.lib;bundle-version="2.7.0";visibility:="privat
  fr.inria.diverse.melange.adapters;bundle-version="0.1.0";visibility:="reexport",
  fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.xdsmlframework.api;bundle-version="0.0.0";visibility:="reexport",
- org.eclipse.gemoc.execution.sequential.javaxdsml.api;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.executionframework.engine;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.executionframework.extensions.sirius;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.gemoc.example.k3fsm;bundle-version="0.0.0";visibility:="reexport",

--- a/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/plugin.xml
+++ b/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-  <extension point="org.eclipse.gemoc.gemoc_language_workbench.sequential.xdsml">
+  <extension point="org.eclipse.gemoc.gemoc_language_workbench.xdsml">
     <XDSML_Definition name="org.eclipse.gemoc.example.k3fsm.K3fsm" xdsmlFilePath="platform:/plugin/org.eclipse.gemoc.example.k3fsm.xdsml/K3fsm.dsl" modelLoader_class="org.eclipse.gemoc.executionframework.extensions.sirius.modelloader.DefaultModelLoader" />
   </extension>
 </plugin>

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.fsm/META-INF/MANIFEST.MF
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.fsm/META-INF/MANIFEST.MF
@@ -16,11 +16,9 @@ Require-Bundle: org.eclipse.xtend.lib;bundle-version="2.7.0";visibility:="privat
  fr.inria.diverse.melange.adapters;bundle-version="0.1.0";visibility:="reexport",
  fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.xdsmlframework.api;bundle-version="0.0.0";visibility:="reexport",
- org.eclipse.gemoc.execution.sequential.javaxdsml.api;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.executionframework.engine;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.example.melangek3fsm.fsm.model;bundle-version="0.0.0";visibility:="private",
  org.eclipse.gemoc.executionframework.extensions.sirius;bundle-version="0.0.0";visibility:=reexport,
  org.eclipse.gemoc.example.melangek3fsm.fsm.k3dsa;bundle-version="0.0.0";visibility:="reexport"
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.fsm/plugin.xml
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.fsm/plugin.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?eclipse version="3.4"?><!--
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<!--
     Copyright (c) 2015, 2017  Inria  and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -8,15 +9,15 @@
    
     Contributors:
         Inria - initial API and implementation
- --><plugin>
-  <extension point="org.eclipse.gemoc.gemoc_language_workbench.sequential.xdsml">
-    <XDSML_Definition modelLoader_class="org.eclipse.gemoc.executionframework.extensions.sirius.modelloader.DefaultModelLoader" name="org.eclipse.gemoc.example.melangek3fsm.fsm.FSM" xdsmlFilePath="platform:/plugin/org.eclipse.gemoc.example.melangek3fsm.fsm/src/org/eclipse/gemoc/example/melangek3fsm/fsm/FSM.dsl"/>
-  </extension>
-  
-<extension point="fr.inria.diverse.melange.modeltype">
-    <modeltype id="org.eclipse.gemoc.example.melangek3fsm.fsm.FSMMT" uri="http://org.eclipse.gemoc.example.melangek3fsm.fsm.fsmmt/"/>
+ -->
+<plugin>
+  <extension point="fr.inria.diverse.melange.modeltype">
+    <modeltype id="org.eclipse.gemoc.example.melangek3fsm.fsm.FSMMT" uri="http://org.eclipse.gemoc.example.melangek3fsm.fsm.fsmmt/" />
   </extension>
   <extension point="fr.inria.diverse.melange.language">
-    <language aspects="" entryPoints="" exactType="org.eclipse.gemoc.example.melangek3fsm.fsm.FSMMT" id="org.eclipse.gemoc.example.melangek3fsm.fsm.FSM" uri="http://www.gemoc.org/legacyfsm/fsm"/>
+    <language aspects="" entryPoints="" exactType="org.eclipse.gemoc.example.melangek3fsm.fsm.FSMMT" id="org.eclipse.gemoc.example.melangek3fsm.fsm.FSM" uri="http://www.gemoc.org/legacyfsm/fsm" />
+  </extension>
+  <extension point="org.eclipse.gemoc.gemoc_language_workbench.xdsml">
+    <XDSML_Definition name="org.eclipse.gemoc.example.melangek3fsm.fsm.FSM" xdsmlFilePath="platform:/plugin/org.eclipse.gemoc.example.melangek3fsm.fsm/src/org/eclipse/gemoc/example/melangek3fsm/fsm/FSM.dsl" modelLoader_class="org.eclipse.gemoc.executionframework.extensions.sirius.modelloader.DefaultModelLoader" />
   </extension>
 </plugin>

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm/plugin.xml
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm/plugin.xml
@@ -5,7 +5,7 @@
     <!-- @generated XSFSM -->
     <package uri="http://org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm/fsm/" class="org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.FsmPackage" genModel="model/XSFSM.genmodel" />
   </extension>
-  <extension point="org.eclipse.gemoc.gemoc_language_workbench.sequential.xdsml">
+  <extension point="org.eclipse.gemoc.gemoc_language_workbench.xdsml">
     <XDSML_Definition name="org.eclipse.gemoc.example.melangek3fsm.xsfsm.XSFSM" xdsmlFilePath="platform:/plugin/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm/XSFSM.dsl" modelLoader_class="org.eclipse.gemoc.executionframework.extensions.sirius.modelloader.DefaultModelLoader" />
   </extension>
 </plugin>

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm/META-INF/MANIFEST.MF
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm/META-INF/MANIFEST.MF
@@ -22,7 +22,6 @@ Require-Bundle: org.eclipse.xtend.lib;bundle-version="2.7.0";visibility:="privat
  fr.inria.diverse.melange.adapters;bundle-version="0.1.0";visibility:="reexport",
  fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.xdsmlframework.api;bundle-version="0.0.0";visibility:="reexport",
- org.eclipse.gemoc.execution.sequential.javaxdsml.api;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.executionframework.engine;bundle-version="0.0.0";visibility:="reexport",
  org.eclipse.gemoc.example.melangek3fsm.fsm.model;bundle-version="0.0.0";visibility:="private",
  org.eclipse.gemoc.example.melangek3fsm.fsm.k3dsa;bundle-version="0.0.0";visibility:="private",


### PR DESCRIPTION
Companion PR to https://github.com/eclipse/gemoc-studio-modeldebugging/pull/133

It adapts the examples to the removal of the `org.eclipse.gemoc.gemoc_language_workbench.sequential.xdsml` extension point

It adapts the release engineering to the removal of `org.eclipse.gemoc.execution.sequential.javaxdsml.api` plugin