### PR TITLE
Use custom docker image for building the studio on the CI

### DIFF
--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -32,17 +32,14 @@ RUN yum update -y \
   && yum install -y \
   autoconf \
   automake \
-  boost-test \
   blas \
   blas-devel \
-  cmake \
-  cppcheck \
   createrepo \
-  doxygen \
   e2fsprogs-devel \
-  gcc \
-  gcc-c++ \
+  ffmpeg \
+  ffmpeg-devel \
   git \
+  graphviz \
   gtk3 \
   ImageMagick \
   ImageMagick-devel \
@@ -59,7 +56,6 @@ RUN yum update -y \
   metacity \
   mutter \
   net-snmp-devel.x86_64 \
-  okular \
   java-1.8.0-openjdk-devel \
   openssl-devel.x86_64 \
   patch \
@@ -75,9 +71,6 @@ RUN yum update -y \
   tcpdump \
   tcsh \
   telnet \
-  texlive \
-  texlive-latex \
-  texlive-tex4ht \
   tigervnc \
   tigervnc-server \
   tk \

--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -77,7 +77,6 @@ RUN yum update -y \
   telnet \
   tigervnc \
   tigervnc-server \
-  tmux \
   tk \
   unrar \
   unzip \

--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -28,6 +28,10 @@ ENTRYPOINT [ "uid_entrypoint", "jenkins-slave" ]
 RUN yum install -y yum-utils && \
   yum install -y https://centos7.iuscommunity.org/ius-release.rpm
 
+# https://linuxize.com/post/how-to-install-ffmpeg-on-centos-7/
+RUN rpm -v --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
+RUN rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+
 RUN yum update -y \
   && yum install -y \
   autoconf \

--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -73,6 +73,7 @@ RUN yum update -y \
   telnet \
   tigervnc \
   tigervnc-server \
+  tmux \
   tk \
   unrar \
   unzip \


### PR DESCRIPTION
This PR contributes a new docker images that is based on https://github.com/eclipse-cbi/jiro/tree/master/jenkins-agent-images/migration-fat-agent

this migration-fat-agent is the image used when using 
```
agent   {  
      kubernetes {
        label 'migration'
      }
    }
``` 
in the jenkins file


This modified image allows to:
- remove some useless tool in the image
- add graphviz:  fix  https://github.com/eclipse/gemoc-studio/issues/151
- add ffmpeg and tmux (in order to try to capture video of the x display of tests)


the docker image is deployed https://hub.docker.com/repository/docker/gemoc/gemoc-jenkins-fat-agent in order to be used by the jenkinsfile (see https://github.com/gemoc/gemoc-studio-eclipse-integration )
