### PR TITLE
Bump to Sirius 6.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<timesquare.p2.url>http://www.i3s.unice.fr/~deantoni/photon/</timesquare.p2.url>
 		<!--             <url>http://timesquare.inria.fr/update_site/photon</url> -->
 		<diverse-commons.p2.url>http://www.kermeta.org/diverse-commons/updates/latest</diverse-commons.p2.url>
-		<sirius.p2.url>http://download.eclipse.org/sirius/updates/releases/6.0.1/photon</sirius.p2.url>
+		<sirius.p2.url>http://download.eclipse.org/sirius/updates/releases/6.1.3/photon</sirius.p2.url>
 	</properties>
 
 	<build>


### PR DESCRIPTION
This PR bumps Sirius from 6.0.2 to 6.1.3

This is the companion PR of https://github.com/eclipse/gemoc-studio-modeldebugging/pull/138