### PR TITLE
Fix xdsmlFilePath attribute in plugin.xml

### DIFF
--- a/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/plugin.xml
+++ b/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.xdsml/plugin.xml
@@ -2,6 +2,6 @@
 <?eclipse version="3.4"?>
 <plugin>
   <extension point="org.eclipse.gemoc.gemoc_language_workbench.xdsml">
-    <XDSML_Definition name="org.eclipse.gemoc.example.k3fsm.K3fsm" xdsmlFilePath="platform:/plugin/org.eclipse.gemoc.example.k3fsm.xdsml/K3fsm.dsl" modelLoader_class="org.eclipse.gemoc.executionframework.extensions.sirius.modelloader.DefaultModelLoader" />
+    <XDSML_Definition name="org.eclipse.gemoc.example.k3fsm.K3fsm" xdsmlFilePath="/org.eclipse.gemoc.example.k3fsm.xdsml/K3fsm.dsl" modelLoader_class="org.eclipse.gemoc.executionframework.extensions.sirius.modelloader.DefaultModelLoader" />
   </extension>
 </plugin>


### PR DESCRIPTION

Companion PR to https://github.com/eclipse/gemoc-studio-modeldebugging/pull/139

This PR fixes the xdsmlFilePath attribute in plugin.xml of the examples

contributes to
https://github.com/eclipse/gemoc-studio-modeldebugging/issues/137
