### PR TITLE
Move JavaEngine to its own dedicated git repository

### DIFF
--- a/dev_support/full_compilation/pom.xml
+++ b/dev_support/full_compilation/pom.xml
@@ -15,6 +15,7 @@
 		<module>../../../gemoc-studio/docs/org.eclipse.gemoc.studio.doc</module>
 		<module>../../../gemoc-studio/gemoc_studio</module>
 		<module>../../../gemoc-studio-modeldebugging</module>
+		<module>../../../gemoc-studio-execution-java</module>
 		<module>../../../gemoc-studio-execution-ale</module>
 		<module>../../../gemoc-studio-moccml</module>
 		<module>../../../gemoc-studio-execution-moccml</module>

--- a/docs/org.eclipse.gemoc.studio.doc/pom.xml
+++ b/docs/org.eclipse.gemoc.studio.doc/pom.xml
@@ -119,7 +119,7 @@
 							    </resource>
 							    
 							    <resource>
-							        <directory>${basedir}/../../../gemoc-studio-modeldebugging/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/docs/asciidoc/images</directory>
+							        <directory>${basedir}/../../../gemoc-studio-execution-java/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/docs/asciidoc/images</directory>
 							        <targetPath>images</targetPath>
 							    </resource>
 							    <resource>
@@ -167,7 +167,7 @@
 							        <targetPath>images</targetPath>
 							    </resource>
 							    <resource>
-							        <directory>${basedir}/../../../gemoc-studio-modeldebugging/java_execution/docs/dev/images</directory>
+							        <directory>${basedir}/../../../gemoc-studio-execution-java/docs/dev/images</directory>
 							        <targetPath>images</targetPath>
 							    </resource>
 							    <resource>

--- a/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/master.asciidoc
+++ b/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/master.asciidoc
@@ -71,7 +71,7 @@ include::userguide/lw_DefineConcreteSyntax_headContent.asciidoc[]
 
 include::userguide/lw_MakeLanguageExecutable_headContent.asciidoc[]
 
-include::../../../../../../gemoc-studio-modeldebugging/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/docs/asciidoc/user_lw_MakeK3SequentialExecutableLanguage.asciidoc[]
+include::../../../../../../gemoc-studio-execution-java/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/docs/asciidoc/user_lw_MakeK3SequentialExecutableLanguage.asciidoc[]
 
 include::../../../../org.eclipse.gemoc.studio.externaltools.doc/src/main/asciidoc/ccsljavaxdsml/user_lw_MakeCCSLJavaConcurrentExecutableLanguage.asciidoc[]
 
@@ -155,7 +155,7 @@ include::userguide/mw_ExecuteModel_headContent.asciidoc[]
 ==== Launch a model execution
 // include::userguide/mw_LaunchModelExecution_headContent.asciidoc[]
 
-include::../../../../../../gemoc-studio-modeldebugging/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/docs/asciidoc/user_mw_LaunchSequentialModelExecution.asciidoc[]
+include::../../../../../../gemoc-studio-execution-java/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/docs/asciidoc/user_mw_LaunchSequentialModelExecution.asciidoc[]
 
 include::../../../../org.eclipse.gemoc.studio.externaltools.doc/src/main/asciidoc/ccsljavaxdsml/user_mw_LaunchConcurrentModelExecution.asciidoc[]
 
@@ -196,10 +196,10 @@ include::../../../../../../gemoc-studio-modeldebugging/framework/execution_frame
 include::userguide/mw_DebugModel_Timelines_headContent.asciidoc[]
 
 include::../../../../../../gemoc-studio-modeldebugging/trace/manager/plugins/org.eclipse.gemoc.addon.multidimensional.timeline/docs/asciidoc/user_mw_DebugModel_MultiDimentionalTimeline.asciidoc[]
-include::../../../../../../gemoc-studio-modeldebugging/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/docs/asciidoc/user_mw_DebugModel_MultiDimentionalTimeline_javaengine.asciidoc[]
+include::../../../../../../gemoc-studio-execution-java/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/docs/asciidoc/user_mw_DebugModel_MultiDimentionalTimeline_javaengine.asciidoc[]
 
 include::../../../../org.eclipse.gemoc.studio.externaltools.doc/src/main/asciidoc/ccsljavaxdsml/user_mw_DebugModel_MultiBranchTimeline.asciidoc[]
-include::../../../../../../gemoc-studio-modeldebugging/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/docs/asciidoc/user_mw_DebugModel_MultiBranchTimeline_javaengine.asciidoc[]
+include::../../../../../../gemoc-studio-execution-java/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/docs/asciidoc/user_mw_DebugModel_MultiBranchTimeline_javaengine.asciidoc[]
 
 include::../../../../../../gemoc-studio-modeldebugging/trace/manager/plugins/org.eclipse.gemoc.addon.diffviewer/docs/asciidoc/user_mw_DebugModel_Timeline_diff_view.asciidoc[]
 include::../../../../../../gemoc-studio-modeldebugging/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/docs/asciidoc/user_mw_DebugModel_Timeline_state_graph_view.asciidoc[]
@@ -320,7 +320,7 @@ include::../../../../../../gemoc-studio-modeldebugging/trace/docs/dev/TraceManag
 === Execution engines
 
 
-include::../../../../../../gemoc-studio-modeldebugging/java_execution/docs/dev/JavaExecution.asciidoc[]
+include::../../../../../../gemoc-studio-execution-java/docs/dev/JavaExecution.asciidoc[]
 include::../../../../../../gemoc-studio-execution-ale/docs/dev/ALEExecution.asciidoc[]
 
 


### PR DESCRIPTION
Companion PR to https://github.com/eclipse/gemoc-studio-modeldebugging/pull/147


This PR adapts the build scripts and updates the documentation link to the new git repository https://github.com/eclipse/gemoc-studio-execution-java/ .

Contributes to https://github.com/eclipse/gemoc-studio-modeldebugging/issues/78