### PR TITLE
Deploy GEMOC artefacts to maven repository (repo.eclipse.org)

### DIFF
--- a/dev_support/full_compilation/pom.xml
+++ b/dev_support/full_compilation/pom.xml
@@ -9,6 +9,9 @@
 	<version>3.0.0-SNAPSHOT</version>
 	<name>Complete GEMOC Studio compilation</name>
 
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
 	<modules>
 		<module>../../../gemoc-studio/official_samples/sample.deployers</module>
 		<module>../../../gemoc-studio/docs/org.eclipse.gemoc.studio.doc</module>
@@ -19,5 +22,16 @@
 		<module>../../../gemoc-studio-moccml</module>
 		<module>../../../gemoc-studio-execution-moccml</module>
 	</modules>
-
+	<distributionManagement>
+		<repository>
+			<id>repo.eclipse.org</id>
+			<name>GEMOC Project Repository - Releases</name>
+			<url>https://repo.eclipse.org/content/repositories/gemoc-releases/</url>
+		</repository>
+		<snapshotRepository>
+			<id>repo.eclipse.org</id>
+			<name>GEMOC Project Repository - Snapshots</name>
+			<url>https://repo.eclipse.org/content/repositories/gemoc-snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
 </project>

--- a/docs/org.eclipse.gemoc.studio.doc/pom.xml
+++ b/docs/org.eclipse.gemoc.studio.doc/pom.xml
@@ -13,8 +13,10 @@
 
     <properties>
         <!-- Distribution URLs -->
-        <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
-        <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
+        <gemoc.releases.repo.url>https://repo.eclipse.org/content/repositories/gemoc-releases/</gemoc.releases.repo.url>
+        <gemoc.snapshots.repo.url>https://repo.eclipse.org/content/repositories/gemoc-snapshots/</gemoc.snapshots.repo.url>
+        
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <scm>
@@ -38,14 +40,14 @@
 
     <distributionManagement>
         <repository>
-            <id>jboss-releases-repository</id>
-            <name>JBoss Releases Repository</name>
-            <url>${jboss.releases.repo.url}</url>
+            <id>repo.eclipse.org</id>
+            <name>GEMOC Releases Repository</name>
+            <url>${gemoc.releases.repo.url}</url>
         </repository>
         <snapshotRepository>
-            <id>jboss-snapshots-repository</id>
-            <name>JBoss Snapshots Repository</name>
-            <url>${jboss.snapshots.repo.url}</url>
+            <id>repo.eclipse.org</id>
+            <name>GEMOC Snapshots Repository</name>
+            <url>${gemoc.snapshots.repo.url}</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -211,4 +211,16 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+	<distributionManagement>
+		<repository>
+			<id>repo.eclipse.org</id>
+			<name>Project Repository - Releases</name>
+			<url>https://repo.eclipse.org/content/repositories/project-releases/</url>
+		</repository>
+		<snapshotRepository>
+			<id>repo.eclipse.org</id>
+			<name>Project Repository - Snapshots</name>
+			<url>https://repo.eclipse.org/content/repositories/project-snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 		<timesquare.p2.url>http://timesquare.inria.fr/update_site/photon</timesquare.p2.url>
 		<diverse-commons.p2.url>http://www.kermeta.org/diverse-commons/updates/latest</diverse-commons.p2.url>
 		<sirius.p2.url>http://download.eclipse.org/sirius/updates/releases/6.1.3/photon</sirius.p2.url>
+		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -214,13 +214,13 @@
 	<distributionManagement>
 		<repository>
 			<id>repo.eclipse.org</id>
-			<name>Project Repository - Releases</name>
-			<url>https://repo.eclipse.org/content/repositories/project-releases/</url>
+			<name>GEMOC Project Repository - Releases</name>
+			<url>https://repo.eclipse.org/content/repositories/gemoc-releases/</url>
 		</repository>
 		<snapshotRepository>
 			<id>repo.eclipse.org</id>
-			<name>Project Repository - Snapshots</name>
-			<url>https://repo.eclipse.org/content/repositories/project-snapshots/</url>
+			<name>GEMOC Project Repository - Snapshots</name>
+			<url>https://repo.eclipse.org/content/repositories/gemoc-snapshots/</url>
 		</snapshotRepository>
 	</distributionManagement>
 </project>


### PR DESCRIPTION
This PR add some DistributionManagement information allowing to deploy GEMOC artefact in a standard maven repository (ie. not P2)  so we can create dependencies to the jars using the maven style in pure java application.

This PR selects a set of jars to be deployed (by using the `<maven.deploy.skip>true</maven.deploy.skip>` property)

The CI currently deploys to https://repo.eclipse.org/content/groups/gemoc/
To use the artefacts, simply add the following in your pom.xml (or equivalent in graddle files)

```
	<repositories>
		<repository>
			<id>nexus-eclipse-gemoc</id>
			<name>Nexus Eclipse GEMOC</name>
			<releases><enabled>true</enabled></releases>
			<snapshots><enabled>true</enabled></snapshots>
			<url>https://repo.eclipse.org/content/groups/gemoc/</url>
		</repository>
	</repositories>
```

then add as many dependencies to GEMOC jar as you need:

ex:
```
	<dependencies>
		<dependency>
			<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
			<artifactId>org.eclipse.gemoc.xdsmlframework.api</artifactId>
			<version>4.0.0-SNAPSHOT</version>
			<type>eclipse-plugin</type>
		</dependency>
	</dependencies>
``` 

**The approach is still incomplete for the following reasons:**
- the distributed jar files are the very same as the plugins in eclipse, including the pom.xml. This means that there are **no explicit dependencies between the jars** (as they are defined in the manifest and not in the pom.xml) Dependencies must be added explicitly in your local pom.xml to get a running application. (they don't even provide a dependency to EMF so you're free to use your own version)
- **snapshot artefacts are maintained only 30 days** (cf. https://wiki.eclipse.org/Services/Nexus)  if there is no recent build on the master branch the snapshot artefact may be removed for the repo
- we currently have no "simple" way to create distribution version (ie. without the .qualifier in the manifest.mf / SNAPSHOT in pom.xml during the creation of GEMOC releases (Currently it probably requires to manually edit a lot of pom.xml and manifest.mf files) Any help is welcome to provide a script that would help during this task