### PR TITLE
Fix machine-id of the jenkins docker image

### DIFF
--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -101,7 +101,8 @@ RUN yum update -y \
   && yum clean all
 
 RUN ln -s /usr/bin/git /usr/local/bin/git \
-  && ln -s /bin/bash /usr/local/bin/hipp_shell
+  && ln -s /bin/bash /usr/local/bin/hipp_shell \
+  && if [ ! -a /etc/machine-id ] || [ ! -s /etc/machine-id ]; then dbus-uuidgen > /etc/machine-id; fi
 
 ENV HOME=/home/jenkins
 ENV DISPLAY :0


### PR DESCRIPTION
Yesterday, the CI suddenly failed when starting the UI tests due to empty /etc/machine-id error

> process 5465: D-Bus library appears to be incorrectly set up; failed to read machine uuid: UUID file '/etc/machine-id' should contain a hex string of length 32, not length 0, with no other text
See the manual page for dbus-uuidgen to correct this issue.
  D-Bus not built with -rdynamic so unable to print a backtrace

This PR updates the docker image by copying
https://github.com/eclipse-cbi/jiro-agents/blob/a892e25179578ba4d99abc79524d1ecdbf25d4dd/centos-7/Dockerfile#L93 to create a machine-id in the docker image

