### PR TITLE
Model execution protocol support for engines

### DIFF
--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/pom.xml
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/pom.xml
@@ -96,6 +96,11 @@
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.gemoc.execution.sequential.javaengine</groupId>
+			<artifactId>org.eclipse.gemoc.execution.sequential.javaengine.headless.mep</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.gemoc.pomfirst</groupId>
 			<artifactId>org.eclipse.gemoc.commons.utils</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
@@ -153,6 +158,21 @@
 		<dependency>
 			<groupId>org.eclipse.gemoc.pomfirst</groupId>
 			<artifactId>org.eclipse.gemoc.executionframework.engine</artifactId>
+			<version>4.0.0-SNAPSHOT</version>
+		</dependency>
+	    <dependency>
+		    <groupId>org.eclipse.gemoc.commons</groupId>
+			<artifactId>org.eclipse.gemoc.commons.eclipse.pde</artifactId>
+			<version>3.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.gemoc.commons</groupId>
+			<artifactId>org.eclipse.gemoc.commons.eclipse.messagingsystem.api</artifactId>
+			<version>3.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
+			<artifactId>org.eclipse.gemoc.xdsmlframework.commons</artifactId>
 			<version>4.0.0-SNAPSHOT</version>
 		</dependency>
 

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMGemocMEPServerImpl.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMGemocMEPServerImpl.java
@@ -4,7 +4,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.gemoc.example.k3fsm.K3FSMStandaloneSetup;
 import org.eclipse.gemoc.example.k3fsm.K3fsmPackage;
 import org.eclipse.gemoc.execution.sequential.javaengine.headless.mep.HeadlessPlainK3ExecutionEngineMEP;
-import org.eclipse.gemoc.executionframework.mep.launch.GemocMEPServerImpl;
+import org.eclipse.gemoc.executionframework.mep.launch.MEPServerLSP4J;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.slf4j.Logger;
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.inject.Injector;
 
-public class K3FSMGemocMEPServerImpl extends GemocMEPServerImpl {
+public class K3FSMGemocMEPServerImpl extends MEPServerLSP4J {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(K3FSMGemocMEPServerImpl.class);
 		

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMGemocMEPServerImpl.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMGemocMEPServerImpl.java
@@ -1,16 +1,10 @@
 package org.eclipse.gemoc.example.k3fsm.mep.server;
 
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.gemoc.example.k3fsm.K3FSMStandaloneSetup;
 import org.eclipse.gemoc.example.k3fsm.K3fsmPackage;
-import org.eclipse.gemoc.execution.sequential.javaengine.headless.AbstractHeadlessExecutionContext;
-import org.eclipse.gemoc.execution.sequential.javaengine.headless.HeadlessExecutionPlatform;
-import org.eclipse.gemoc.execution.sequential.javaengine.headless.HeadlessExecutionWorkspace;
-import org.eclipse.gemoc.execution.sequential.javaengine.headless.mep.K3GemocMEPServerImpl;
-import org.eclipse.gemoc.executionframework.engine.commons.EngineContextException;
-import org.eclipse.gemoc.executionframework.engine.commons.sequential.ISequentialRunConfiguration;
-import org.eclipse.gemoc.xdsmlframework.api.core.ExecutionMode;
+import org.eclipse.gemoc.execution.sequential.javaengine.headless.HeadlessPlainK3ExecutionEngineMEP;
+import org.eclipse.gemoc.executionframework.mep.launch.GemocMEPServerImpl;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.slf4j.Logger;
@@ -18,13 +12,12 @@ import org.slf4j.LoggerFactory;
 
 import com.google.inject.Injector;
 
-public class K3FSMGemocMEPServerImpl extends K3GemocMEPServerImpl<K3FSMLanguageDefinitionExtension> {
+public class K3FSMGemocMEPServerImpl extends GemocMEPServerImpl {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(K3FSMGemocMEPServerImpl.class);
 		
 	public K3FSMGemocMEPServerImpl() {
-		super();
-		languageDefinition = new K3FSMLanguageDefinitionExtension();
+		super(new HeadlessPlainK3ExecutionEngineMEP<K3FSMLanguageDefinitionExtension>(new K3FSMLanguageDefinitionExtension()));
 	}
 	
 	/**
@@ -42,21 +35,6 @@ public class K3FSMGemocMEPServerImpl extends K3GemocMEPServerImpl<K3FSMLanguageD
 		resourceSet.addLoadOption(XtextResource.OPTION_RESOLVE_ALL, Boolean.TRUE);
 		LOGGER.info("created K3FSM XtextResourceSet");
 		return resourceSet;
-	}
-
-	@Override
-	protected AbstractHeadlessExecutionContext<ISequentialRunConfiguration, K3FSMLanguageDefinitionExtension> newExecutionContext(Resource resourceModel) throws EngineContextException {
-		return new AbstractHeadlessExecutionContext<ISequentialRunConfiguration, K3FSMLanguageDefinitionExtension>(
-				runConfiguration, 
-				ExecutionMode.Run, 
-				languageDefinition, 
-				new HeadlessExecutionWorkspace(), 
-				new HeadlessExecutionPlatform()){				
-					@Override
-					public void initializeResourceModel() {
-						_resourceModel = resourceModel;
-					}
-			};
 	}
 	
 }

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMGemocMEPServerImpl.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMGemocMEPServerImpl.java
@@ -3,7 +3,7 @@ package org.eclipse.gemoc.example.k3fsm.mep.server;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.gemoc.example.k3fsm.K3FSMStandaloneSetup;
 import org.eclipse.gemoc.example.k3fsm.K3fsmPackage;
-import org.eclipse.gemoc.execution.sequential.javaengine.headless.HeadlessPlainK3ExecutionEngineMEP;
+import org.eclipse.gemoc.execution.sequential.javaengine.headless.mep.HeadlessPlainK3ExecutionEngineMEP;
 import org.eclipse.gemoc.executionframework.mep.launch.GemocMEPServerImpl;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMMEPServerEndpoint.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMMEPServerEndpoint.java
@@ -18,20 +18,12 @@ import javax.websocket.OnOpen;
 import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
+
 import org.eclipse.gemoc.commons.utils.ExtensibleInputStream;
-import org.eclipse.gemoc.example.k3fsm.K3FSMStandaloneSetupGenerated;
-import org.eclipse.gemoc.executionframework.mep.launch.GemocMEPServerImpl;
+
 import org.eclipse.gemoc.executionframework.mep.launch.MEPLauncher;
 import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;
-import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolServer;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
-import org.eclipse.lsp4j.launch.LSPLauncher;
-import org.eclipse.lsp4j.services.LanguageClient;
-import org.eclipse.xtext.ide.server.LanguageServerImpl;
-import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.resource.XtextResourceSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMMEPServerEndpoint.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/K3FSMMEPServerEndpoint.java
@@ -125,7 +125,6 @@ public class K3FSMMEPServerEndpoint {
 					System.out.println("[DEBUG] Sent: " + response);
 				}
 			};
-			
 			Launcher<IModelExecutionProtocolClient> serverSideLauncher = MEPLauncher.createLauncher(server, IModelExecutionProtocolClient.class, in, outputstream);
 			server.connect(serverSideLauncher.getRemoteProxy());
 

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/MockClientMain.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/MockClientMain.java
@@ -1,32 +1,9 @@
 package org.eclipse.gemoc.example.k3fsm.mep.server;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.gemoc.executionframework.mep.launch.GemocMEPServerImpl;
 import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;
-import org.eclipse.lsp4j.DidOpenTextDocumentParams;
-import org.eclipse.lsp4j.DocumentFormattingParams;
-import org.eclipse.lsp4j.FormattingOptions;
-import org.eclipse.lsp4j.InitializeParams;
-import org.eclipse.lsp4j.InitializedParams;
-import org.eclipse.lsp4j.Location;
-import org.eclipse.lsp4j.MessageActionItem;
-import org.eclipse.lsp4j.MessageParams;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.PublishDiagnosticsParams;
-import org.eclipse.lsp4j.ReferenceContext;
-import org.eclipse.lsp4j.ReferenceParams;
-import org.eclipse.lsp4j.RenameParams;
-import org.eclipse.lsp4j.ShowMessageRequestParams;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
-import org.eclipse.lsp4j.TextDocumentItem;
-import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4j.WorkspaceEdit;
+
 import org.eclipse.lsp4j.debug.BreakpointEventArguments;
 import org.eclipse.lsp4j.debug.CapabilitiesEventArguments;
 import org.eclipse.lsp4j.debug.ContinuedEventArguments;
@@ -39,11 +16,6 @@ import org.eclipse.lsp4j.debug.ProcessEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.TerminatedEventArguments;
 import org.eclipse.lsp4j.debug.ThreadEventArguments;
-import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
-import org.eclipse.lsp4j.services.LanguageClient;
-import org.eclipse.xtext.ide.server.LanguageServerImpl;
-import org.eclipse.xtext.nodemodel.INode;
-import org.eclipse.xtext.resource.XtextResource;
 
 
 

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/MockClientMain.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/main/java/org/eclipse/gemoc/example/k3fsm/mep/server/MockClientMain.java
@@ -1,7 +1,7 @@
 package org.eclipse.gemoc.example.k3fsm.mep.server;
 
 
-import org.eclipse.gemoc.executionframework.mep.launch.GemocMEPServerImpl;
+import org.eclipse.gemoc.executionframework.mep.launch.MEPServerLSP4J;
 import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;
 
 import org.eclipse.lsp4j.debug.BreakpointEventArguments;
@@ -23,7 +23,7 @@ public class MockClientMain {
 	
 	public static void main(String[] args) {
 		try {
-			GemocMEPServerImpl server = new K3FSMMEPModule().createInjectorAndDoEMFRegistration().getInstance(GemocMEPServerImpl.class);
+			MEPServerLSP4J server = new K3FSMMEPModule().createInjectorAndDoEMFRegistration().getInstance(MEPServerLSP4J.class);
 			
 //			new LogoIdeSetup().createInjectorAndDoEMFRegistration();
 //			ASMPackage rootPkg = ASMPackage.eINSTANCE;

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/test/java/org/eclipse/gemoc/example/k3fsm/mep/server/tests/dap/commands/InitializeCommandTest.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/test/java/org/eclipse/gemoc/example/k3fsm/mep/server/tests/dap/commands/InitializeCommandTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ExecutionException;
 import org.eclipse.gemoc.example.k3fsm.mep.server.K3FSMGemocMEPServerImpl;
 import org.eclipse.gemoc.example.k3fsm.mep.server.K3FSMMEPModule;
 import org.eclipse.gemoc.example.k3fsm.mep.server.tests.commands.MockTestClient;
-import org.eclipse.gemoc.executionframework.mep.launch.GemocMEPServerImpl;
+import org.eclipse.gemoc.executionframework.mep.launch.MEPServerLSP4J;
 import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;
 import org.eclipse.lsp4j.debug.Capabilities;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
@@ -19,7 +19,7 @@ public class InitializeCommandTest {
 	@Test
     void checkCapabilitiesTest() throws InterruptedException, ExecutionException {
         
-		GemocMEPServerImpl server = new K3FSMMEPModule().createInjectorAndDoEMFRegistration().getInstance(K3FSMGemocMEPServerImpl.class);
+		MEPServerLSP4J server = new K3FSMMEPModule().createInjectorAndDoEMFRegistration().getInstance(K3FSMGemocMEPServerImpl.class);
 		IModelExecutionProtocolClient mockClient = new MockTestClient();
 		server.connect(mockClient);
 

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/test/java/org/eclipse/gemoc/example/k3fsm/mep/server/tests/dap/commands/LaunchCommandTest.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/test/java/org/eclipse/gemoc/example/k3fsm/mep/server/tests/dap/commands/LaunchCommandTest.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ExecutionException;
 import org.eclipse.gemoc.example.k3fsm.mep.server.K3FSMGemocMEPServerImpl;
 import org.eclipse.gemoc.example.k3fsm.mep.server.K3FSMMEPModule;
 import org.eclipse.gemoc.example.k3fsm.mep.server.tests.commands.MockTestClient;
-import org.eclipse.gemoc.executionframework.mep.launch.GemocMEPServerImpl;
+import org.eclipse.gemoc.executionframework.mep.launch.MEPServerLSP4J;
 import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;
 import org.eclipse.lsp4j.debug.Capabilities;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
@@ -22,7 +22,7 @@ public class LaunchCommandTest {
 	@Test
     void checkCapabilitiesTest() throws InterruptedException, ExecutionException {
         
-		GemocMEPServerImpl server = new K3FSMMEPModule().createInjectorAndDoEMFRegistration().getInstance(K3FSMGemocMEPServerImpl.class);
+		MEPServerLSP4J server = new K3FSMMEPModule().createInjectorAndDoEMFRegistration().getInstance(K3FSMGemocMEPServerImpl.class);
 		IModelExecutionProtocolClient mockClient = new MockTestClient();
 		server.connect(mockClient);
 

--- a/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/test/java/org/eclipse/gemoc/example/k3fsm/mep/server/tests/integration/commands/MEPIntegrationTest.java
+++ b/official_samples/K3FSM/pomfirst/org.eclipse.gemoc.example.k3fsm.mep.server/src/test/java/org/eclipse/gemoc/example/k3fsm/mep/server/tests/integration/commands/MEPIntegrationTest.java
@@ -19,7 +19,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.gemoc.example.k3fsm.mep.server.K3FSMGemocMEPServerImpl;
 import org.eclipse.gemoc.example.k3fsm.mep.server.K3FSMMEPModule;
 import org.eclipse.gemoc.example.k3fsm.mep.server.tests.integration.commands.TestClient.Status;
-import org.eclipse.gemoc.executionframework.mep.launch.GemocMEPServerImpl;
+import org.eclipse.gemoc.executionframework.mep.launch.MEPServerLSP4J;
 import org.eclipse.gemoc.executionframework.mep.launch.MEPLaunchParameterKey;
 import org.eclipse.gemoc.executionframework.mep.launch.MEPLauncher;
 import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;


### PR DESCRIPTION
This PR aims to better define a MEP Engine in the context of GEMOC, and to properly separate existing engines and their support of the protocol.

The envisioned architecture is the following:
![Architecture MEP Java](https://user-images.githubusercontent.com/7363343/84521132-df712580-acd4-11ea-867f-4cf48da740c0.png)

Basically, existing engines should not be modified to support MEP, and support should be added as extensions.
The fact that we currently rely on a LSP4J server should not have any impact on the rest, and thus all dependencies to LSP4J were isolated.

