### PR TITLE
Add Sirius ELK support

### DIFF
--- a/gemoc_studio/pom.xml
+++ b/gemoc_studio/pom.xml
@@ -85,11 +85,11 @@
 			<layout>p2</layout>
 			<url>${elk.p2.url}</url>
 		</repository>
-<!-- 		<repository> -->
-<!-- 			<id>APP4MC</id> -->
-<!-- 			<layout>p2</layout> -->
-<!-- 			<url>${app4mc.p2.url}</url> -->
-<!-- 		</repository> -->
+		<repository>
+			<id>Sirius</id>
+			<layout>p2</layout>
+			<url>${sirius.p2.url}</url>
+		</repository>
 		<repository>
 			<id>AspectJ</id>
 			<layout>p2</layout>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
@@ -96,10 +96,11 @@ http://www.eclipse.org/legal/epl-v10.html
       <import feature="org.eclipse.ajdt" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.fx.ide.basic.feature" version="2.2.0.201508240705" match="greaterOrEqual"/>
       <import feature="org.eclipse.fx.ide.pde.feature" version="2.2.0.201508240705" match="greaterOrEqual"/>
-      <import feature="org.eclipse.sirius.runtime.ide.xtext" version="5.0.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.sirius.specifier" version="5.0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.sirius.runtime.ide.xtext" version="6.0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.sirius.specifier" version="6.0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.sirius.diagram.elk.feature" version="6.0.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.amalgam.discovery.modeling"/>
-      <import feature="org.eclipse.elk.feature" version="0.1.0.201607121925" match="greaterOrEqual"/>
+      <import feature="org.eclipse.elk.feature" version="0.7.0" match="greaterOrEqual"/>
       <import plugin="openjfx.base"/>
       <import plugin="openjfx.controls"/>
       <import plugin="openjfx.fxml"/>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
@@ -167,5 +167,5 @@
    <repository-reference location="http://melange.inria.fr/updatesite/nightly/update" enabled="true" />
    <repository-reference location="http://www.kermeta.org/diverse-commons/updates/latest" enabled="true" />
    <repository-reference location="http://download.eclipse.org/elk/updates/releases/0.7.1/" enabled="true" />
-   <repository-reference location="http://download.eclipse.org/tools/ajdt/48/dev/update" enabled="true" />
+   <repository-reference location="http://download.eclipse.org/tools/ajdt/410/dev/update" enabled="true" />
 </site>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
@@ -161,7 +161,6 @@
          Individual components that are part of GEMOC and coming from https://github.com/eclipse/gemoc-studio-moccml/
       </description>
    </category-def>
-   <repository-reference location="http://download.eclipse.org/nebula/snapshot/" enabled="true" />
    <repository-reference location="http://www.kermeta.org/k3/update_2018-09-05" enabled="true" />
    <repository-reference location="http://www.kermeta.org/ale-lang/updates/latest" enabled="true" />
    <repository-reference location="http://melange.inria.fr/updatesite/nightly/update" enabled="true" />

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
@@ -166,6 +166,6 @@
    <repository-reference location="http://www.kermeta.org/ale-lang/updates/latest" enabled="true" />
    <repository-reference location="http://melange.inria.fr/updatesite/nightly/update" enabled="true" />
    <repository-reference location="http://www.kermeta.org/diverse-commons/updates/latest" enabled="true" />
-   <repository-reference location="http://download.eclipse.org/elk/updates/releases/0.4.1/" enabled="true" />
+   <repository-reference location="http://download.eclipse.org/elk/updates/releases/0.7.1/" enabled="true" />
    <repository-reference location="http://download.eclipse.org/tools/ajdt/48/dev/update" enabled="true" />
 </site>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
@@ -78,7 +78,6 @@ openFile
 
    <repositories>
       <repository location="http://melange-lang.org/updatesite/" enabled="true" />
-      <repository location="http://archive.eclipse.org/nebula/Q22016/incubation" enabled="true" />
       <repository location="http://download.eclipse.org/releases/2020-12" enabled="true" />
       <repository location="http://download.eclipse.org/eclipse/updates/4.15/" enabled="true" />
       <repository location="http://www.kermeta.org/k3/update/" enabled="true" />

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
@@ -85,7 +85,7 @@ openFile
       <repository location="http://www.kermeta.org/ale-lang/updates/latest/" enabled="true" />
       <repository location="http://timesquare.inria.fr/update_site/2020" enabled="true" />
       <repository location="http://download.eclipse.org/gemoc/updates/nightly/" enabled="true" />
-      <repository location="http://download.eclipse.org/elk/updates/releases/0.4.1" enabled="false" />
+      <repository location="http://download.eclipse.org/elk/updates/releases/0.7.1" enabled="false" />
       <repository location="http://download.eclipse.org/tools/ajdt/410/dev/update" enabled="true" />
       <repository location="http://downloads.efxclipse.bestsolution.at/p2-repos/openjfx-11/repository/" enabled="true" />
    </repositories>

--- a/official_samples/K3FSM/language_workbench/pom.xml
+++ b/official_samples/K3FSM/language_workbench/pom.xml
@@ -44,20 +44,5 @@
 			<layout>p2</layout>
 			<url>${melange.p2.url}</url>
 		</repository>
-		<!-- <repository> -->
-		<!-- <id>ELK</id> -->
-		<!-- <layout>p2</layout> -->
-		<!-- <url>${elk.p2.url}</url> -->
-		<!-- </repository> -->
-<!-- 		<repository> -->
-<!-- 			<id>APP4MC</id> -->
-<!-- 			<layout>p2</layout> -->
-<!-- 			<url>${app4mc.p2.url}</url> -->
-<!-- 		</repository> -->
-		<!-- <repository> -->
-		<!-- <id>AspectJ</id> -->
-		<!-- <layout>p2</layout> -->
-		<!-- <url>${aspectJ.p2.url}</url> -->
-		<!-- </repository> -->
 	</repositories>
 </project>

--- a/official_samples/sample.deployers/pom.xml
+++ b/official_samples/sample.deployers/pom.xml
@@ -35,31 +35,6 @@
 			<layout>p2</layout>
 			<url>${eclipse.release.p2.url}</url>
 		</repository>
-<!-- 		<repository> -->
-<!-- 			<id>K3</id> -->
-<!-- 			<layout>p2</layout> -->
-<!-- 			<url>${k3.p2.url}</url> -->
-<!-- 		</repository> -->
-<!-- 		<repository> -->
-<!-- 			<id>Melange</id> -->
-<!-- 			<layout>p2</layout> -->
-<!-- 			<url>${melange.p2.url}</url> -->
-<!-- 		</repository> -->
-		<!-- <repository> -->
-		<!-- <id>ELK</id> -->
-		<!-- <layout>p2</layout> -->
-		<!-- <url>${elk.p2.url}</url> -->
-		<!-- </repository> -->
-<!-- 		<repository> -->
-<!-- 			<id>APP4MC</id> -->
-<!-- 			<layout>p2</layout> -->
-<!-- 			<url>${app4mc.p2.url}</url> -->
-<!-- 		</repository> -->
-		<!-- <repository> -->
-		<!-- <id>AspectJ</id> -->
-		<!-- <layout>p2</layout> -->
-		<!-- <url>${aspectJ.p2.url}</url> -->
-		<!-- </repository> -->
 	</repositories>
 	
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,9 @@
 		<ale.p2.url>http://www.kermeta.org/ale-lang/updates/2020-07-17</ale.p2.url>
 		<!-- <ale.p2.url>https://ci.inria.fr/gemoc/job/ale-lang/job/bump-to-eclipse-2020-03/lastSuccessfulBuild/artifact/releng/org.eclipse.emf.ecoretools.ale.updatesite/target/repository/</ale.p2.url>-->
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange.p2.url>
-		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.4.1</elk.p2.url>
+		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.7.1</elk.p2.url>
+		<!-- for advanced sirius features such as Sirius ELK support , version needs to be aligned with the one  in ${eclipse.release.p2.url}-->
+		<sirius.p2.url>https://download.eclipse.org/sirius/updates/releases/6.4.1/2020-09/</sirius.p2.url>
 		<app4mc.p2.url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.1</app4mc.p2.url>
 		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/410/dev/update</aspectJ.p2.url>
 		<timesquare.p2.url>http://timesquare.inria.fr/update_site/2020</timesquare.p2.url>
@@ -116,16 +118,6 @@
 							<ws>gtk</ws>
 							<arch>x86_64</arch>
 						</environment>
-					<!-- 	<environment>
-							<os>linux</os>
-							<ws>gtk</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
-							<arch>x86</arch>
-						</environment> -->
 						<environment>
 							<os>win32</os>
 							<ws>win32</ws>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
 		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.7.1</elk.p2.url>
 		<!-- for advanced sirius features such as Sirius ELK support , version needs to be aligned with the one  in ${eclipse.release.p2.url}-->
 		<sirius.p2.url>https://download.eclipse.org/sirius/updates/releases/6.4.1/2020-09/</sirius.p2.url>
-		<app4mc.p2.url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.1</app4mc.p2.url>
 		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/410/dev/update</aspectJ.p2.url>
 		<timesquare.p2.url>http://timesquare.inria.fr/update_site/2020</timesquare.p2.url>
 		<diverse-commons.p2.url>http://www.kermeta.org/diverse-commons/updates/latest</diverse-commons.p2.url>


### PR DESCRIPTION
## Description

This PR adds the ELK experimental support for Sirius. It provides better autolayout for Sirius diagram.

It also 
- cleans up some of the P2 repositories used while building
- remove some old repositories in the list of update sites presented in "Available update site" of the studio 

## Changes

ELK -> 0.7.1
Sirius ELK support
AJDT 4.10
remove nebula update site

 
## Contribution to issues

Closes https://github.com/eclipse/gemoc-studio/issues/221

## Companion Pull Requests

- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/184
- https://github.com/eclipse/gemoc-studio-execution-java/pull/15
- https://github.com/eclipse/gemoc-studio-execution-moccml/pull/50
- https://github.com/eclipse/gemoc-studio-moccml/pull/18

