### PR TITLE
[Event Manager] Update MW test case for small change in model stack trace

### DIFF
--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DebugOfficialExampleK3FSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DebugOfficialExampleK3FSM_Test.xtend
@@ -250,7 +250,7 @@ class DebugOfficialExampleK3FSM_Test extends AbstractXtextTests
 		bot.tree().getTreeItem("K3FSM - TwoStatesUpcast(abababa) [Executable model with GEMOC Java engine]").waitNode("Gemoc debug target").waitNode("Model debugging").select();
 		bot.tree().getTreeItem("K3FSM - TwoStatesUpcast(abababa) [Executable model with GEMOC Java engine]").getNode("Gemoc debug target").getNode("Model debugging").expand();
 		bot.tree().getTreeItem("K3FSM - TwoStatesUpcast(abababa) [Executable model with GEMOC Java engine]").getNode("Gemoc debug target").getNode("Model debugging").waitNode("Engine : TwoStatesUpcast.k3fsm => TwoStateUpcast").select();
-		bot.tree().getTreeItem("K3FSM - TwoStatesUpcast(abababa) [Executable model with GEMOC Java engine]").getNode("Gemoc debug target").getNode("Model debugging").waitNode("[FSM] TwoStateUpcast#initializeModel()").select();
+		bot.tree().getTreeItem("K3FSM - TwoStatesUpcast(abababa) [Executable model with GEMOC Java engine]").getNode("Gemoc debug target").getNode("Model debugging").waitNode("[FSM] TwoStateUpcast#initializeModel([])").select();
 		
 		
 		closeXtextProjectConversionPopup


### PR DESCRIPTION
## Description

Makes a tiny change to a test case in order to take into account the new label of stack frames when debugging models. This new label is due to changes made to the GEMOC execution framework to introduce the management of parameters in execution steps.


## Changes

In `DebugOfficialExampleK3FSM_Test`, replace 
 ```FSM] TwoStateUpcast#initializeModel()``` 
by 
```FSM] TwoStateUpcast#initializeModel([])```
 
## Contribution to issues

None

## Companion Pull Requests

- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/186
- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/187
