### PR TITLE
Disable flacky tests

### DIFF
--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DebugOfficialExampleK3FSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DebugOfficialExampleK3FSM_Test.xtend
@@ -55,6 +55,7 @@ import org.eclipse.debug.core.DebugEvent
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
+import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine
 
 /**
  * Verifies that we can execute a debug session 
@@ -193,7 +194,7 @@ class DebugOfficialExampleK3FSM_Test extends AbstractXtextTests
 		assertEquals(5,engine.engineStatus.nbLogicalStepRun)
 		assertEquals("S1",fsm.currentState.name)
 		
-		closeAndClearEngine
+		closeAndClearEngineProgrammatically
 		
 		helper.assertNoMarkers();	
 	}
@@ -227,7 +228,7 @@ class DebugOfficialExampleK3FSM_Test extends AbstractXtextTests
 		assertEquals("ABABABA",fsm.producedString)
 		assertEquals("",fsm.unprocessedString)
 		
-		closeAndClearEngine
+		closeAndClearEngineProgrammatically
 	}
 	
 	// some reusabe test part
@@ -294,6 +295,18 @@ class DebugOfficialExampleK3FSM_Test extends AbstractXtextTests
 		bot.viewByTitle("Gemoc Engines Status").show();
 		bot.toolbarButtonWithTooltip("Stop selected engines").click();
 		bot.toolbarButtonWithTooltip("Dispose all stopped engines").click();
+				
+		assertTrue("runningEngineRegistry not empty " +runningEnginesRegistry.runningEngines,  runningEnginesRegistry.runningEngines.size == 0)
+	}
+	
+	def static void closeAndClearEngineProgrammatically() {
+		val runningEnginesRegistry = org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry;
+		
+		// The Engine view used by closeAndClearEngine() tends to be flacky in Test suites, close and dispose manually
+		for(IExecutionEngine<?> e : runningEnginesRegistry.runningEngines.values) {
+			e.stop
+			e.dispose
+		}
 		
 		assertTrue("runningEngineRegistry not empty " +runningEnginesRegistry.runningEngines,  runningEnginesRegistry.runningEngines.size == 0)
 	}

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DebugOfficialExampleK3FSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DebugOfficialExampleK3FSM_Test.xtend
@@ -53,6 +53,8 @@ import org.junit.AfterClass
 import org.eclipse.debug.core.IDebugEventSetListener
 import org.eclipse.debug.core.DebugEvent
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
 
 /**
  * Verifies that we can execute a debug session 
@@ -115,6 +117,20 @@ class DebugOfficialExampleK3FSM_Test extends AbstractXtextTests
 	override tearDown() {
 		GEMOCTestVideoHelper.addTestSuiteVideoLog("   - END of "+testName.methodName);
 	}
+	
+	/** print SWTBot context on failure */
+	@Rule(order=Integer.MIN_VALUE)
+	public TestWatcher watchman = new TestWatcher() {
+		override void failed(Throwable e, Description description) {
+			println("FAILED test: " + description )
+			SWTBotHelper.printSWTBotStatus(bot)
+		}
+
+		override void succeeded(Description description) {
+			println(description + " success!")
+			//SWTBotHelper.printSWTBotStatus(bot)
+		}
+	};
 	
 	/**
 	 * Stop is done using Engine Status view

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DeployOfficialExampleK3FSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DeployOfficialExampleK3FSM_Test.xtend
@@ -45,6 +45,8 @@ import org.eclipse.debug.internal.core.LaunchManager
 import org.eclipse.gemoc.xdsmlframework.test.lib.SWTBotHelper
 import org.junit.rules.TestName
 import org.eclipse.gemoc.xdsmlframework.test.lib.GEMOCTestVideoHelper
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
 
 /**
  * Verifies that we can use the wizard to install the official sample models 
@@ -97,6 +99,20 @@ class DeployOfficialExampleK3FSM_Test extends AbstractXtextTests
 	override tearDown() {
 		// Nothing to do
 	}
+	
+	/** print SWTBot context on failure */
+	@Rule(order=Integer.MIN_VALUE)
+	public TestWatcher watchman = new TestWatcher() {
+		override void failed(Throwable e, Description description) {
+			println("FAILED test: " + description )
+			SWTBotHelper.printSWTBotStatus(bot)
+		}
+
+		override void succeeded(Description description) {
+			println(description + " success!")
+			//SWTBotHelper.printSWTBotStatus(bot)
+		}
+	};
 	
 	/**
 	 * verifies that the example models installation proceeds correctly

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DeployOfficialExampleK3MelangeFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DeployOfficialExampleK3MelangeFSM_Test.xtend
@@ -31,6 +31,9 @@ import org.eclipse.gemoc.xdsmlframework.test.lib.TailWorkspaceLogToStderrRule
 import org.junit.Rule
 import org.eclipse.gemoc.xdsmlframework.test.lib.GEMOCTestVideoHelper
 import org.junit.rules.TestName
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.eclipse.gemoc.xdsmlframework.test.lib.SWTBotHelper
 
 /**
  * Verifies that we can use the wizard to install the official sample models
@@ -82,6 +85,20 @@ class DeployOfficialExampleK3MelangeFSM_Test extends AbstractXtextTests
 	override tearDown() {
 		// Nothing to do
 	}
+	
+	/** print SWTBot context on failure */
+	@Rule(order=Integer.MIN_VALUE)
+	public TestWatcher watchman = new TestWatcher() {
+		override void failed(Throwable e, Description description) {
+			println("FAILED test: " + description )
+			SWTBotHelper.printSWTBotStatus(bot)
+		}
+
+		override void succeeded(Description description) {
+			println(description + " success!")
+			//SWTBotHelper.printSWTBotStatus(bot)
+		}
+	};
 	
 	@Test
 	def void test01_InstallK3MelangeFsmModels() throws Exception {


### PR DESCRIPTION
## Description

This PR improves the tests

- Improvement of the log of the SWT widget in order to analyze them
- replace the use of SWTbot by direct programming of the close and dispose engine
 
## Changes

<!-- more details , changed documentation sections, changed version, some details about the code changes -->
 
 -
 
## Contribution to issues

Contribute to https://github.com/eclipse/gemoc-studio/issues/123
Flaky tests are not really fixed, we only use direct programming instead of using SWTBot (apparently the Engine view doesn't display its buttons in some situations)

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - PR https://github.com/eclipse/gemoc-studio-modeldebugging/pull/192
