### PR TITLE
Remove eclipse.jgit logback logs in tycho tests

### DIFF
--- a/gemoc_studio/pom.xml
+++ b/gemoc_studio/pom.xml
@@ -38,6 +38,7 @@
 		<!-- Tests -->
 		<module>tests/org.eclipse.gemoc.studio.tests.system.lwb</module>
 		<module>tests/org.eclipse.gemoc.studio.tests.system.mwb</module>
+		<module>tests/org.eclipse.gemoc.studio.tests.logging.config</module>
 		<!-- backlog tests are not part of the main CI build <module>tests/org.eclipse.gemoc.studio.tests.system.backlog</module> -->
 
 

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/.classpath
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/.project
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.gemoc.studio.tests.logging.config</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/.settings/org.eclipse.jdt.core.prefs
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/META-INF/MANIFEST.MF
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: GEMOC Test Logging Config
+Bundle-SymbolicName: org.eclipse.gemoc.studio.tests.logging.config
+Bundle-Version: 3.3.0.qualifier
+Bundle-Activator: org.eclipse.gemoc.studio.tests.logging.config.Activator
+Require-Bundle: org.eclipse.core.runtime,
+ ch.qos.logback.classic;bundle-version="1.2.3",
+ ch.qos.logback.core;bundle-version="1.2.3"
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Automatic-Module-Name: org.eclipse.gemoc.studio.tests.logging.config
+Bundle-ActivationPolicy: lazy
+Import-Package: org.slf4j;version="1.7.30",
+ org.slf4j.spi;version="1.7.30"

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/build.properties
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               logback.xml

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/logback.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/logback.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<statusListener
+		class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+	<appender name="STDOUT"
+		class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder 
+			by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.eclipse" level="warn" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+	<logger name="org.eclipse.gemoc" level="debug"
+		additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
+	<root level="debug">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Inria and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        Inria - initial API and implementation
+ -->
+
+<project>
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<relativePath>../..</relativePath>
+		<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
+		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
+		<version>3.3.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.gemoc.studio.tests.logging.config</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	
+
+</project>
+

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/src/org/eclipse/gemoc/studio/tests/logging/config/Activator.java
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/src/org/eclipse/gemoc/studio/tests/logging/config/Activator.java
@@ -1,0 +1,47 @@
+package org.eclipse.gemoc.studio.tests.logging.config;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.Path;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+
+public class Activator implements BundleActivator {
+
+	private static BundleContext context;
+
+	static BundleContext getContext() {
+		return context;
+	}
+
+	public void start(BundleContext bundleContext) throws Exception {
+		Activator.context = bundleContext;
+		System.out.println("Activating org.eclipse.gemoc.studio.tests.logging.config");
+        configureLogbackInBundle(bundleContext.getBundle());
+	}
+
+	public void stop(BundleContext bundleContext) throws Exception {
+		Activator.context = null;
+	}
+
+	
+    private void configureLogbackInBundle(Bundle bundle) throws JoranException, IOException {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        JoranConfigurator jc = new JoranConfigurator();
+        jc.setContext(context);
+        context.reset();
+
+        // this assumes that the logback.xml file is in the root of the bundle.
+        URL logbackConfigFileUrl = FileLocator.find(bundle, new Path("logback.xml"),null);
+        jc.doConfigure(logbackConfigFileUrl.openStream());
+    }
+}

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
@@ -51,6 +51,13 @@
               		<systemProperties>
               			<WORKSPACE>${basedir}/../../../..</WORKSPACE>
               		</systemProperties>
+              		<bundleStartLevel>
+              			<bundle>
+	              			<id>org.eclipse.gemoc.studio.tests.logging.config</id>
+	              			<!-- <level>4</level> -->
+	              			<autoStart>true</autoStart>
+              			</bundle>
+              		</bundleStartLevel>
 				</configuration>
 			</plugin>
 		
@@ -158,6 +165,22 @@
 			               <id>org.eclipse.sdk</id>
 			               <versionRange>4.18.0</versionRange>
 			            </requirement>
+			            <!-- avoid debug message from git -->
+			            <requirement>
+			               <type>eclipse-feature</type>
+			               <id>org.eclipse.jgit</id>
+			               <versionRange>5.10.0</versionRange>
+			            </requirement>
+			            <requirement>
+			               <type>eclipse-feature</type>
+			               <id>org.eclipse.egit</id>
+			               <versionRange>5.10.0</versionRange>
+			            </requirement>
+			            <requirement>
+			               <type>eclipse-feature</type>
+			               <id>org.eclipse.pde</id>
+			               <versionRange>3.14.0</versionRange>
+			            </requirement>
 			            <!-- GEMOC components -->
 			            <requirement>
 			               <type>eclipse-feature</type>
@@ -189,6 +212,12 @@
 			               <type>eclipse-feature</type>
 			               <id>org.eclipse.swtbot.ide</id>
 			               <versionRange>3.0.0</versionRange>
+			            </requirement>
+			            
+			            <requirement>
+			               <type>eclipse-plugin</type>
+			               <id>org.eclipse.gemoc.studio.tests.logging.config</id>
+			               <versionRange>0.0.0</versionRange>
 			            </requirement>
 			         </extraRequirements>
 			        

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
@@ -51,6 +51,13 @@
               		<systemProperties>
               			<WORKSPACE>${basedir}/../../../..</WORKSPACE>
               		</systemProperties>
+              		<bundleStartLevel>
+              			<bundle>
+	              			<id>org.eclipse.gemoc.studio.tests.logging.config</id>
+	              			<!-- <level>4</level> -->
+	              			<autoStart>true</autoStart>
+              			</bundle>
+              		</bundleStartLevel>
 				</configuration>
 			</plugin>
 		
@@ -140,6 +147,11 @@
 			               <type>eclipse-feature</type>
 			               <id>org.eclipse.swtbot.ide</id>
 			               <versionRange>3.0.0</versionRange>
+			            </requirement>
+			            <requirement>
+			               <type>eclipse-plugin</type>
+			               <id>org.eclipse.gemoc.studio.tests.logging.config</id>
+			               <versionRange>0.0.0</versionRange>
 			            </requirement>
 			         </extraRequirements>
 			        


### PR DESCRIPTION

## Description

Clean the maven tycho output by removing logback based logs produced by org.eclipse.jgit
It introduces a new plugin `org.eclipse.gemoc.studio.tests.logging.config` that must start on product (cf. bundleStartLevel in the tycho-surefire configuration)

