### PR TITLE
Improve docker for CI

### DIFF
--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -130,7 +130,7 @@ ENV DISPLAY :0
 
 RUN mkdir -p ${HOME}/.vnc && chmod -R 775 ${HOME} \
   && echo "123456" | vncpasswd -f > ${HOME}/.vnc/passwd \
-  && chmod 600 ${HOME}/.vnc/passwd
+  && chmod 644 ${HOME}/.vnc/passwd
 
 # Create a custom vnc xstartup file
 COPY scripts/xstartup_mutter.sh ${HOME}/.vnc/xstartup.sh

--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -100,6 +100,19 @@ RUN yum update -y \
   zsh \
   && yum clean all
 
+RUN alternatives --set java /usr/lib/jvm/java-11-openjdk-11.0.12.0.7-0.el7_9.x86_64/bin/java \
+  && alternatives --set javac /usr/lib/jvm/java-11-openjdk-11.0.12.0.7-0.el7_9.x86_64/bin/javac
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-11.0.12.0.7-0.el7_9.x86_64
+
+
+# Setting Maven Version that needs to be installed
+ARG MAVEN_VERSION=3.8.1 
+
+# Maven
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share \
+  && mv /usr/share/apache-maven-$MAVEN_VERSION /usr/share/maven \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ENV M2_HOME /usr/share/maven
 
 ENV HOME=/home/jenkins
 

--- a/dev_support/jenkins/docker/README.asciidoc
+++ b/dev_support/jenkins/docker/README.asciidoc
@@ -20,6 +20,35 @@ docker push gemoc/gemoc-jenkins-fat-agent:latest
 If for some reason you wish to access it interactively you can use the following command:
 [source,bourne]
 ----
-docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 gemoc/gemoc-jenkins-fat-agent:latest /bin/bash
+docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 -p 5900:5900 gemoc/gemoc-jenkins-fat-agent:latest /bin/bash
 ----
+
+
+## Notes about manual build of the studio using this docker container
+
+----
+docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 -p 5900:5900 gemoc/gemoc-jenkins-fat-agent:latest /bin/bash
+----
+
+Build the studio (no test) from the container
+
+```
+cd src/gemoc-studio/dev_support/full_compilation/
+mvn -DskipTests=true -Djava.awt.headless=true -P test_linux install
+```
+
+
+Start system tests (UI) from the container:
+```
+~/.vnc/xstartup.sh
+cd src/gemoc-studio/dev_support/full_compilation/
+mvn --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb verify
+```
+
+connect to vncserver display from your host using a vnc viewer(for example using remmina) on `localhost:5900` (the password is `123456`)
+
+
+ 
+
+
    


### PR DESCRIPTION
## Description

Improve the docker image in order to be able to use it locally (ie. not in the Kubernetes context of Eclipse Jenkins)
Add some tools directly to the image. In Jenkins, java and maven are installed by the Jenkins agent. In order to use this image without the Jenkins agent context, we need to install these tools directly in the image.

## Changes
- use java 11 as the default alternative 
- install maven
- add some instructions about building locally using this image in a way that is similar to Jenkins  (ie. basic mvn commands, connection to vnc using a vncclient, ...)
 