### PR TITLE
re-enable workspace location prompt on startup

### DIFF
--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
@@ -21,6 +21,7 @@ openFile
       </programArgs>
       <vmArgs>-Dosgi.requiredJavaVersion=11
 -Dosgi.instance.area.default=@user.home/eclipse-workspaces/gemoc-workspace
+-Dosgi.dataAreaRequiresExplicitInit=true
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
 -Dosgi.framework.extensions=org.eclipse.fx.osgi


### PR DESCRIPTION

## Description

In recent GEMOC Studio package (3.3.0),  Eclipse isn't prompting anymore for the workspace location on startup.

This PR re-enable this prompt.

## Changes

add `-Dosgi.dataAreaRequiresExplicitInit=true` in the GemocStudio.ini

Fixes https://github.com/eclipse/gemoc-studio/issues/237