### PR TITLE
Fix mvn deploy config

### DIFF
--- a/dev_support/launchconf/gemoc-studio pomfirst_full_compilation.launch
+++ b/dev_support/launchconf/gemoc-studio pomfirst_full_compilation.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-    <stringAttribute key="M2_GOALS" value="clean package dependency:tree"/>
+    <stringAttribute key="M2_GOALS" value="clean install dependency:tree"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
     <stringAttribute key="M2_PROFILES" value=""/>

--- a/dev_support/pomfirst_full_compilation/pom.xml
+++ b/dev_support/pomfirst_full_compilation/pom.xml
@@ -8,6 +8,10 @@
 	
     <packaging>pom</packaging>
 	
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+	
 	<modules>
 		<module>../../gemoc_studio/pomfirst</module>
 		<module>../../../gemoc-studio-modeldebugging/pomfirst</module>

--- a/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
+++ b/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
@@ -35,6 +35,7 @@
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
 		<version>3.4.0-SNAPSHOT</version>
+		<relativePath>..</relativePath>
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
+++ b/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
@@ -8,7 +8,6 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 	<artifactId>gemoc-studio-bom</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>GEMOC Studio BOM</name>
 	<description>GEMOC Studio Third Party Dependencies (Bill of Materials)</description>
@@ -32,6 +31,11 @@
 		<developerConnection>scm:git:git@github.com:eclipse/gemoc-studio.git</developerConnection>
 		<url>git@github.com:eclipse/gemoc-studio.git</url>
 	</scm>
+	<parent>
+		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
+		<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
+		<version>3.4.0-SNAPSHOT</version>
+	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
+++ b/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
@@ -12,25 +12,7 @@
 	<name>GEMOC Studio BOM</name>
 	<description>GEMOC Studio Third Party Dependencies (Bill of Materials)</description>
 	<url>https://www.eclipse.org/gemoc/</url>
-	<licenses>
-		<license>
-			<name>Eclipse Public License, Version 1.0</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
-		</license>
-	</licenses>
-	<developers>
-		<developer>
-			<name>Didier Vojtisek</name>
-			<email>didier.vojtisek@inria.fr</email>
-			<organization>Inria</organization>
-			<organizationUrl>http://www.inria.fr</organizationUrl>
-		</developer>
-	</developers>
-	<scm>
-		<connection>scm:git:git@github.com:eclipse/gemoc-studio.git</connection>
-		<developerConnection>scm:git:git@github.com:eclipse/gemoc-studio.git</developerConnection>
-		<url>git@github.com:eclipse/gemoc-studio.git</url>
-	</scm>
+
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
@@ -61,7 +43,7 @@
 		<!--  MUST BE ALIGNED with xtext bom currently https://github.com/eclipse/xtext-lib/blob/v2.24.0/org.eclipse.xtext.dev-bom/build.gradle -->
 		<emf.edit-version>2.16.0-SNAPSHOT</emf.edit-version>
 		<emf.common-version>2.17.0</emf.common-version><!-- <emf.common-version>[2.16.0,3.0.0)</emf.common-version> -->
-		<emf.ecore-version>2.20.0</emf.ecore-version><!-- <emf.ecore-version>[2.16.0,3.0.0)</emf.ecore-version> -->
+		<emf.ecore-version>2.25.0</emf.ecore-version><!-- <emf.ecore-version>[2.16.0,3.0.0)</emf.ecore-version> -->
 		<emf.ecore.xmi-version>2.16.0</emf.ecore.xmi-version>
 		<emf.compare-version>[3.4.0,3.6.0)</emf.compare-version>
 		<emf.transaction-version>[1.9.0,2.0.0)</emf.transaction-version> 

--- a/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
+++ b/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
@@ -47,8 +47,8 @@
 		<core.runtime-version>3.19.0</core.runtime-version>
 
 		<!-- Eclipse debug dependencies versions -->
-		<debug.core-version>3.15.0.v20200224-0654</debug.core-version>
-		<debug.ui-version>3.14.700.v20201123-0650</debug.ui-version>
+		<debug.core-version>3.15.0-SNAPSHOT</debug.core-version>
+		<debug.ui-version>3.14.700-SNAPSHOT</debug.ui-version>
 		
 		<!-- Eclipse equinox dependencies versions -->
 		<equinox.common-version>3.13.0</equinox.common-version>
@@ -59,7 +59,7 @@
 
 		<!-- Eclipse EMF dependencies versions -->
 		<!--  MUST BE ALIGNED with xtext bom currently https://github.com/eclipse/xtext-lib/blob/v2.24.0/org.eclipse.xtext.dev-bom/build.gradle -->
-		<emf.edit-version>2.16.0.20190920</emf.edit-version>
+		<emf.edit-version>2.16.0-SNAPSHOT</emf.edit-version>
 		<emf.common-version>2.17.0</emf.common-version><!-- <emf.common-version>[2.16.0,3.0.0)</emf.common-version> -->
 		<emf.ecore-version>2.20.0</emf.ecore-version><!-- <emf.ecore-version>[2.16.0,3.0.0)</emf.ecore-version> -->
 		<emf.ecore.xmi-version>2.16.0</emf.ecore.xmi-version>

--- a/gemoc_studio/pomfirst/pom.xml
+++ b/gemoc_studio/pomfirst/pom.xml
@@ -12,4 +12,17 @@
 		<module>gemoc-studio-bom</module>
 		<module>thirdparty-bundle</module>
 	</modules>
+	
+	<distributionManagement>
+		<repository>
+			<id>repo.eclipse.org</id>
+			<name>GEMOC Project Repository - Releases</name>
+			<url>https://repo.eclipse.org/content/repositories/gemoc-releases/</url>
+		</repository>
+		<snapshotRepository>
+			<id>repo.eclipse.org</id>
+			<name>GEMOC Project Repository - Snapshots</name>
+			<url>https://repo.eclipse.org/content/repositories/gemoc-snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
 </project>

--- a/gemoc_studio/pomfirst/pom.xml
+++ b/gemoc_studio/pomfirst/pom.xml
@@ -2,7 +2,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
+	<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 	<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
 	<version>3.4.0-SNAPSHOT</version>
 	

--- a/gemoc_studio/pomfirst/pom.xml
+++ b/gemoc_studio/pomfirst/pom.xml
@@ -13,6 +13,30 @@
 		<module>thirdparty-bundle</module>
 	</modules>
 	
+	<organization>
+		<name>Eclipse</name>
+		<url>https://www.eclipse.org</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>Eclipse Public License, Version 1.0</name>
+			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Didier Vojtisek</name>
+			<email>didier.vojtisek@inria.fr</email>
+			<organization>Inria</organization>
+			<organizationUrl>http://www.inria.fr</organizationUrl>
+		</developer>
+	</developers>
+	<scm>
+		<connection>scm:git:git@github.com:eclipse/gemoc-studio.git</connection>
+		<developerConnection>scm:git:git@github.com:eclipse/gemoc-studio.git</developerConnection>
+		<url>git@github.com:eclipse/gemoc-studio.git</url>
+	</scm>
+	
 	<distributionManagement>
 		<repository>
 			<id>repo.eclipse.org</id>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 	<artifactId>org.eclipse.debug.core</artifactId>
-	<version>3.15.0.v20200224-0654</version>
+	<version>3.15.0.v20200224-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.debug.core osgi bundle without maven dependencies</description>
 

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
@@ -9,22 +9,14 @@
 	<version>3.15.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.debug.core osgi bundle without maven dependencies</description>
-
+	<url>https://www.eclipse.org/gemoc/</url>
+	
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
 		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 
-	<!-- <dependencies>
-		<dependency>
-			<groupId>org.eclipse.debug</groupId>
-			<artifactId>${project.artifactId}</artifactId>
-			<version>${project.version}</version>
-			<scope>system</scope>
-			<systemPath>${project.basedir}/${project.artifactId}_${project.version}.jar</systemPath>
-		</dependency>
-	</dependencies> -->
 	<build>
 		<plugins>
 			<plugin>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
@@ -10,11 +10,11 @@
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.debug.core osgi bundle without maven dependencies</description>
 
-	<!-- <parent>
+	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
 		<version>3.4.0-SNAPSHOT</version>
-	</parent> -->
+	</parent>
 
 	<!-- <dependencies>
 		<dependency>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 	<artifactId>org.eclipse.debug.core</artifactId>
-	<version>3.15.0.v20200224-0654</version>
+	<version>3.15.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.debug.core osgi bundle without maven dependencies</description>
 
@@ -36,7 +36,7 @@
 		            <configuration>
 		               <tasks>
 		                  <echo message="unzipping file" />
-		                  <unzip src="${project.basedir}/${project.artifactId}_${project.version}.jar" dest="${project.build.directory}/classes/" />
+		                  <unzip src="${project.basedir}/${project.artifactId}_3.15.0.v20200224-0654.jar" dest="${project.build.directory}/classes/" />
 		               </tasks>
 		            </configuration>
 		            <goals>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 	<artifactId>org.eclipse.debug.core</artifactId>
-	<version>3.15.0.v20200224-SNAPSHOT</version>
+	<version>3.15.0.v20200224-0654</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.debug.core osgi bundle without maven dependencies</description>
 
@@ -46,5 +46,18 @@
 		      </executions>
 		   </plugin>
 	   </plugins>
-   </build>
+	</build>
+   
+	<distributionManagement>
+		<repository>
+			<id>repo.eclipse.org</id>
+			<name>GEMOC Project Repository - Releases</name>
+			<url>https://repo.eclipse.org/content/repositories/gemoc-releases/</url>
+		</repository>
+		<snapshotRepository>
+			<id>repo.eclipse.org</id>
+			<name>GEMOC Project Repository - Snapshots</name>
+			<url>https://repo.eclipse.org/content/repositories/gemoc-snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
 </project>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.ui/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.ui/pom.xml
@@ -8,7 +8,8 @@
 	<version>3.14.700-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.debug.ui osgi bundle without maven dependencies</description>
-
+	<url>https://www.eclipse.org/gemoc/</url>
+	
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.ui/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.ui/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 	<artifactId>org.eclipse.debug.ui</artifactId>
-	<version>3.14.700.v20201123-0650</version>
+	<version>3.14.700-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.debug.ui osgi bundle without maven dependencies</description>
 
@@ -26,7 +26,7 @@
 		            <configuration>
 		               <tasks>
 		                  <echo message="unzipping file" />
-		                  <unzip src="${project.basedir}/${project.artifactId}_${project.version}.jar" dest="${project.build.directory}/classes/" />
+		                  <unzip src="${project.basedir}/${project.artifactId}_3.14.700.v20201123-0650.jar" dest="${project.build.directory}/classes/" />
 		               </tasks>
 		            </configuration>
 		            <goals>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.ui/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.ui/pom.xml
@@ -9,7 +9,12 @@
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.debug.ui osgi bundle without maven dependencies</description>
 
-
+	<parent>
+		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
+		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
+		<version>3.4.0-SNAPSHOT</version>
+	</parent>
+	
 	<build>
 		<plugins>
 			<plugin>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.compare/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.compare/pom.xml
@@ -9,6 +9,7 @@
 	<version>3.5.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.emf.compare osgi bundle without maven dependencies</description>
+	<url>https://www.eclipse.org/gemoc/</url>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.compare/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.compare/pom.xml
@@ -10,6 +10,12 @@
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.emf.compare osgi bundle without maven dependencies</description>
 
+	<parent>
+		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
+		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
+		<version>3.4.0-SNAPSHOT</version>
+	</parent>
+	
 	<build>
 		<plugins>
 			<plugin>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.compare/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.compare/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 	<artifactId>org.eclipse.emf.compare</artifactId>
-	<version>3.5.3.202011201248</version>
+	<version>3.5.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.emf.compare osgi bundle without maven dependencies</description>
 
@@ -27,7 +27,7 @@
 		            <configuration>
 		               <tasks>
 		                  <echo message="unzipping file" />
-		                  <unzip src="${project.basedir}/${project.artifactId}_${project.version}.jar" dest="${project.build.directory}/classes/" />
+		                  <unzip src="${project.basedir}/${project.artifactId}_3.5.3.202011201248.jar" dest="${project.build.directory}/classes/" />
 		               </tasks>
 		            </configuration>
 		            <goals>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.edit/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.edit/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 	<artifactId>org.eclipse.emf.edit</artifactId>
-	<version>2.16.0.20190920</version>
+	<version>2.16.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.emf.compare osgi bundle without maven dependencies</description>
 	
@@ -27,7 +27,7 @@
 		            <configuration>
 		               <tasks>
 		                  <echo message="unzipping file" />
-		                  <unzip src="${project.basedir}/${project.artifactId}_${project.version}.jar" dest="${project.build.directory}/classes/" />
+		                  <unzip src="${project.basedir}/${project.artifactId}_2.16.0.20190920.jar" dest="${project.build.directory}/classes/" />
 		               </tasks>
 		            </configuration>
 		            <goals>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.edit/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.edit/pom.xml
@@ -9,7 +9,13 @@
 	<version>2.16.0.20190920</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.emf.compare osgi bundle without maven dependencies</description>
-
+	
+	<parent>
+		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
+		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
+		<version>3.4.0-SNAPSHOT</version>
+	</parent>
+	
 	<build>
 		<plugins>
 			<plugin>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.edit/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.edit/pom.xml
@@ -9,6 +9,7 @@
 	<version>2.16.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.emf.compare osgi bundle without maven dependencies</description>
+	<url>https://www.eclipse.org/gemoc/</url>
 	
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.transaction/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.transaction/pom.xml
@@ -10,6 +10,12 @@
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.emf.transaction osgi bundle without maven dependencies</description>
 
+	<parent>
+		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
+		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
+		<version>3.4.0-SNAPSHOT</version>
+	</parent>
+	
 	<build>
 		<plugins>
 			<plugin>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.transaction/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.transaction/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 	<artifactId>org.eclipse.emf.transaction</artifactId>
-	<version>1.9.1.201805140824</version>
+	<version>1.9.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.emf.transaction osgi bundle without maven dependencies</description>
 
@@ -27,7 +27,7 @@
 		            <configuration>
 		               <tasks>
 		                  <echo message="unzipping file" />
-		                  <unzip src="${project.basedir}/${project.artifactId}_${project.version}.jar" dest="${project.build.directory}/classes/" />
+		                  <unzip src="${project.basedir}/${project.artifactId}_1.9.1.201805140824.jar" dest="${project.build.directory}/classes/" />
 		               </tasks>
 		            </configuration>
 		            <goals>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.transaction/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.transaction/pom.xml
@@ -9,6 +9,7 @@
 	<version>1.9.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>Maven distribution of org.eclipse.emf.transaction osgi bundle without maven dependencies</description>
+	<url>https://www.eclipse.org/gemoc/</url>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/pom.xml
@@ -5,8 +5,8 @@
 	<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 	<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
 	<version>3.4.0-SNAPSHOT</version>
-
 	<packaging>pom</packaging>
+	<url>https://www.eclipse.org/gemoc/</url>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/pom.xml
@@ -12,6 +12,7 @@
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
 		<version>3.4.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modules>
 		<module>org.eclipse.debug.core</module>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/pom.xml
@@ -8,6 +8,11 @@
 
 	<packaging>pom</packaging>
 
+	<parent>
+		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
+		<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
+		<version>3.4.0-SNAPSHOT</version>
+	</parent>
 	<modules>
 		<module>org.eclipse.debug.core</module>
 		<module>org.eclipse.debug.ui</module>
@@ -21,24 +26,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>unpack</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>unpack-dependencies</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${project.build.directory}/classes</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
 	</build>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Description

Fixes deployment to nexus issue

version of thirdparty jar now use a snapshot version instead of a release version (because the nexus doesn't allow to re-deploy already released jars, thus preventing continuous integration on possibly updated pom.xm metadata for the given jar)

add some metadata (url, developer, scm distribution) in prevision of deployment on maven central.

## Changes
