### PR TITLE
Fixes usage of GEMOC updatesite with recent Eclipse package

### DIFF
--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/META-INF/MANIFEST.MF
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.equinox.app,
  org.eclipse.osgi,
  org.eclipse.gemoc.commons.eclipse.messagingsystem.api,
  org.eclipse.gemoc.xdsmlframework.api,
- org.eclipse.sirius.common;bundle-version="6.0.1"
+ org.eclipse.sirius.common
 Bundle-ClassPath: libs/commons-cli.jar,
  .
 Export-Package: org.eclipse.gemoc.gemoc_studio.headless.application

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
@@ -73,10 +73,9 @@ http://www.eclipse.org/legal/epl-v10.html
       <import plugin="org.apache.felix.gogo.shell"/>
       <import plugin="org.eclipse.gemoc.executionframework.engine.ui"/>
       <import plugin="org.eclipse.gemoc.executionframework.debugger"/>
-      <import plugin="org.eclipse.equinox.common"/>
       <import plugin="org.eclipse.osgi"/>
+      <import plugin="org.eclipse.osgi.compatibility.state"/>
       <import plugin="org.eclipse.xtext.xbase"/>
-      <import plugin="org.eclipse.equinox.common"/>
       <import plugin="org.eclipse.xtend.lib"/>
       <import plugin="ch.qos.logback.classic" version="1.0.7" match="greaterOrEqual"/>
       <import plugin="org.eclipse.gemoc.dsl.model" version="1.0.0" match="greaterOrEqual"/>
@@ -90,12 +89,18 @@ http://www.eclipse.org/legal/epl-v10.html
       <import plugin="org.eclipse.compare"/>
       <import plugin="org.eclipse.xtext.builder"/>
       <import plugin="org.eclipse.equinox.registry"/>
-      <import plugin="org.eclipse.equinox.common"/>
       <import plugin="org.eclipse.gemoc.executionframework.reflectivetrace.model"/>
       <import plugin="org.eclipse.emf.transaction"/>
       <import plugin="org.eclipse.gemoc.trace.gemoc.api"/>
       <import plugin="org.eclipse.gemoc.trace.commons.model"/>
       <import plugin="org.eclipse.gemoc.executionframework.event.model"/>
+      <import plugin="javax.annotation"/>
+      <import plugin="org.apache.felix.gogo.command"/>
+      <import plugin="org.eclipse.equinox.app"/>
+      <import plugin="org.eclipse.equinox.console"/>
+      <import plugin="org.eclipse.equinox.p2.console"/>
+      <import plugin="org.eclipse.equinox.p2.directorywatcher"/>
+      <import plugin="org.eclipse.equinox.p2.reconciler.dropins"/>
    </requires>
 
    <plugin
@@ -106,60 +111,10 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.equinox.p2.console"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.reconciler.dropins"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="fr.inria.diverse.melange"
          download-size="0"
          install-size="0"
          version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.felix.gogo.command"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.console"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="javax.annotation"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.directorywatcher"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.osgi.compatibility.state"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         fragment="true"
          unpack="false"/>
 
    <plugin
@@ -178,27 +133,6 @@ http://www.eclipse.org/legal/epl-v10.html
 
    <plugin
          id="org.eclipse.gemoc.dsl.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.app"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.common"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.osgi"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
## Description

Enable use of the GEMOC Update site for recent Eclipse package (Ie. eclipse package newer than the version used to compile the studio/updatesite)

## Changes

replace included plugins by dependency plugins
 
## Contribution to issues

Contributes to https://github.com/eclipse/gemoc-studio/issues/248

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - PR https://github.com/eclipse/gemoc-studio-moccml/pull/21
