### PR TITLE
Bump to 3.5.0

### DIFF
--- a/dev_support/pomfirst_full_compilation/pom.xml
+++ b/dev_support/pomfirst_full_compilation/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.gemoc_studio</groupId>
 	<artifactId>org.eclipse.gemoc.gemoc_studio.pomfirst</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	
     <packaging>pom</packaging>
 	

--- a/dev_support/tycho_full_compilation/pom.xml
+++ b/dev_support/tycho_full_compilation/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 	<artifactId>complete-studio</artifactId>
 	<packaging>pom</packaging>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<name>Full tycho build</name>
 
 	<properties>

--- a/docs/org.eclipse.gemoc.studio.doc/pom.xml
+++ b/docs/org.eclipse.gemoc.studio.doc/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.eclipse.gemoc.documentation</groupId>
     <artifactId>gemoc-studio-documentation</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
     <!-- <packaging>jdocbook</packaging>--> 
     <packaging>jar</packaging>
    

--- a/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
+++ b/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 	<artifactId>gemoc_studio-eclipse-bom</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>GEMOC Studio Eclipse Product BOM</name>
 	<description>GEMOC Studio Eclipse Product Bill of Materials</description>

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/META-INF/MANIFEST.MF
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio
 Bundle-SymbolicName: org.eclipse.gemoc.gemoc_studio.branding;singleton:=true
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.5.0.qualifier
 Bundle-Vendor: Eclipse GEMOC Project
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/META-INF/MANIFEST.MF
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio Headless
 Bundle-SymbolicName: org.eclipse.gemoc.gemoc_studio.headless;singleton:=true
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.5.0.qualifier
 Bundle-Vendor: Eclipse GEMOC Project
 Automatic-Module-Name: org.eclipse.gemoc.headless
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.headless/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 	<artifactId>org.eclipse.gemoc.gemoc_studio.headless</artifactId>

--- a/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/META-INF/MANIFEST.MF
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Documentation
 Bundle-SymbolicName: org.eclipse.gemoc.language_workbench.documentation; singleton:=true
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.5.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.language_workbench.documentation.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.language_workbench.documentation/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.eclipse.gemoc.documentation</groupId>
 			<artifactId>gemoc-studio-documentation</artifactId>
-			<version>3.4.0-SNAPSHOT</version>
+			<version>3.5.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/gemoc_studio/pom.xml
+++ b/gemoc_studio/pom.xml
@@ -12,12 +12,12 @@
 	<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 	<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
 	<name>gemoc-studio/gemoc_studio root with tycho</name>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<properties>

--- a/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
+++ b/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<properties>

--- a/gemoc_studio/pomfirst/pom.xml
+++ b/gemoc_studio/pomfirst/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 	<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	
     <packaging>pom</packaging>
 	

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.core/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.ui/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.debug.ui/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 	
 	<build>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.compare/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.compare/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 	
 	<build>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.edit/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.edit/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 	
 	<build>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.transaction/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/org.eclipse.emf.transaction/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 	
 	<build>

--- a/gemoc_studio/pomfirst/thirdparty-bundle/pom.xml
+++ b/gemoc_studio/pomfirst/thirdparty-bundle/pom.xml
@@ -4,14 +4,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.gemoc-studio.thirdparty.bundle</groupId>
 	<artifactId>org.eclipse.gemoc.gemoc_studio.thirdparty-bundle</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<url>https://www.eclipse.org/gemoc/</url>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modules>
@@ -33,7 +33,7 @@
 			<dependency>
 				<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 				<artifactId>gemoc-studio-bom</artifactId>
-				<version>3.4.0-SNAPSHOT</version>
+				<version>3.5.0-SNAPSHOT</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.gemoc_studio.additions.feature"
       label="GEMOC Studio Additional Features"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
         <artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.gemoc_studio.branding.feature"
       label="GEMOC Studio Main Features"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gemoc.gemoc_studio.branding"
       image="gemocstudio32.png">

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
         <artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.gemoc_studio.headless.feature"
       label="GEMOC Studio Headless Features"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.headless.feature/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
         <artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.gemoc.commons.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.commons.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.commons.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.commons.feature" version="3.5.0.qualifier">
       <category name="GEMOC_3_gemoc-studio_Components"/>
    </feature>
    <feature url="features/org.eclipse.gemoc.ale.interpreted.engine.feature_1.1.0.qualifier.jar" id="org.eclipse.gemoc.ale.interpreted.engine.feature" version="1.1.0.qualifier">
@@ -30,19 +30,19 @@
    <feature url="features/org.eclipse.gemoc.moccml.mapping.transfos.feature_1.0.0.qualifier.jar" id="org.eclipse.gemoc.moccml.mapping.transfos.feature" version="1.0.0.qualifier">
       <category name="GEMOC_8_MOCCML_Components"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.concurrent_addons.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.concurrent_addons.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.concurrent_addons.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.concurrent_addons.feature" version="3.5.0.qualifier">
       <category name="GEMOC_7_Execution MOCCML_Components"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.concurrent_addons.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.concurrent_addons.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.concurrent_addons.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.concurrent_addons.feature" version="3.5.0.qualifier">
       <category name="GEMOC_7_Execution MOCCML_Components"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature" version="3.5.0.qualifier">
       <category name="GEMOC_7_Execution MOCCML_Components"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature" version="3.5.0.qualifier">
       <category name="GEMOC_7_Execution MOCCML_Components"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature" version="3.5.0.qualifier">
       <category name="GEMOC_7_Execution MOCCML_Components"/>
    </feature>
    <feature url="features/org.eclipse.gemoc.executionframework.feature_4.0.0.qualifier.jar" id="org.eclipse.gemoc.executionframework.feature" version="4.0.0.qualifier">
@@ -96,43 +96,43 @@
    <feature url="features/org.eclipse.gemoc.commons.eclipse.jdt.autosrcfolder.feature_3.3.0.qualifier.jar" id="org.eclipse.gemoc.commons.eclipse.jdt.autosrcfolder.feature" version="3.3.0.qualifier">
       <category name="GEMOC_3_gemoc-studio_Components"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.gemoc_studio.additions.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.additions.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.gemoc_studio.additions.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.additions.feature" version="3.5.0.qualifier">
       <category name="GEMOC_1_AllInOne"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.gemoc_studio.branding.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.branding.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.gemoc_studio.branding.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.branding.feature" version="3.5.0.qualifier">
       <category name="GEMOC_1_AllInOne"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.gemoc_studio.headless.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.headless.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.gemoc_studio.headless.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.gemoc_studio.headless.feature" version="3.5.0.qualifier">
       <category name="GEMOC_1_AllInOne"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.moccml.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.execution.moccml.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.moccml.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.execution.moccml.feature" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.moccml.feature.source_3.4.0.qualifier.jar" id="org.eclipse.gemoc.execution.moccml.feature.source" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.moccml.feature.source_3.5.0.qualifier.jar" id="org.eclipse.gemoc.execution.moccml.feature.source" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.java.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.execution.java.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.java.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.execution.java.feature" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.java.feature.source_3.4.0.qualifier.jar" id="org.eclipse.gemoc.execution.java.feature.source" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.java.feature.source_3.5.0.qualifier.jar" id="org.eclipse.gemoc.execution.java.feature.source" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.modeldebugging.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.modeldebugging.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.modeldebugging.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.modeldebugging.feature" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.modeldebugging.feature.source_3.4.0.qualifier.jar" id="org.eclipse.gemoc.modeldebugging.feature.source" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.modeldebugging.feature.source_3.5.0.qualifier.jar" id="org.eclipse.gemoc.modeldebugging.feature.source" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.moccml.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.moccml.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.moccml.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.moccml.feature" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.moccml.feature.source_3.4.0.qualifier.jar" id="org.eclipse.gemoc.moccml.feature.source" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.moccml.feature.source_3.5.0.qualifier.jar" id="org.eclipse.gemoc.moccml.feature.source" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.ale.feature_3.4.0.qualifier.jar" id="org.eclipse.gemoc.execution.ale.feature" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.ale.feature_3.5.0.qualifier.jar" id="org.eclipse.gemoc.execution.ale.feature" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.ale.feature.source_3.4.0.qualifier.jar" id="org.eclipse.gemoc.execution.ale.feature.source" version="3.4.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.ale.feature.source_3.5.0.qualifier.jar" id="org.eclipse.gemoc.execution.ale.feature.source" version="3.5.0.qualifier">
       <category name="GEMOC_2_RootComponents"/>
    </feature>
    <category-def name="GEMOC_1_AllInOne" label="GEMOC all in one">

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Gemoc Studio" uid="gemoc_studio" id="org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio" application="org.eclipse.ui.ide.workbench" version="3.4.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Gemoc Studio" uid="gemoc_studio" id="org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio" application="org.eclipse.ui.ide.workbench" version="3.5.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <image path="/org.eclipse.gemoc.gemoc_studio.branding/images/GemocStudioAboutImage.png"/>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio_headless.product
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio_headless.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="GEMOC Headless EngineRunner" uid="gemoc_studio_headless" id="org.eclipse.gemoc.gemoc_studio.headless.GemocStudioHeadless" application="org.eclipse.gemoc.gemoc_studio.headless.EngineRunner" version="3.4.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="GEMOC Headless EngineRunner" uid="gemoc_studio_headless" id="org.eclipse.gemoc.gemoc_studio.headless.GemocStudioHeadless" application="org.eclipse.gemoc.gemoc_studio.headless.EngineRunner" version="3.5.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <text>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/pom.xml
@@ -9,13 +9,13 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.gemoc_studio.updatesite</artifactId>
 	<packaging>eclipse-repository</packaging>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<build>
 		<resources>
 			<resource>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/META-INF/MANIFEST.MF
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Test Logging Config
 Bundle-SymbolicName: org.eclipse.gemoc.studio.tests.logging.config
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.5.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.studio.tests.logging.config.Activator
 Require-Bundle: org.eclipse.core.runtime,
  ch.qos.logback.classic;bundle-version="1.2.3",

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.logging.config/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.studio.tests.logging.config</artifactId>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.backlog/META-INF/MANIFEST.MF
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.backlog/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio Test System Backlog
 Bundle-SymbolicName: org.eclipse.gemoc.studio.tests.system.backlog
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.5.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui;bundle-version="2.4.0",
  org.junit;bundle-version="4.12.0",

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.backlog/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.backlog/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.studio.tests.system.backlog</artifactId>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/META-INF/MANIFEST.MF
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio Test System
 Bundle-SymbolicName: org.eclipse.gemoc.studio.tests.system.lwb
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.5.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui;bundle-version="3.1.0",
  org.junit;bundle-version="4.12.0",

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.studio.tests.system.lwb</artifactId>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/META-INF/MANIFEST.MF
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC Studio Test System
 Bundle-SymbolicName: org.eclipse.gemoc.studio.tests.system.mwb
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.5.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui;bundle-version="3.1.0",
  org.junit;bundle-version="4.12.0",

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.studio.tests.system.mwb</artifactId>

--- a/official_samples/K3FSM/language_workbench/pom.xml
+++ b/official_samples/K3FSM/language_workbench/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
     	<artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
-    	<version>3.4.0-SNAPSHOT</version>
+    	<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../../../gemoc_studio</relativePath>
 	</parent>
 	

--- a/official_samples/sample.deployers/pom.xml
+++ b/official_samples/sample.deployers/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
-    	<version>3.4.0-SNAPSHOT</version>
+    	<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
 	<groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
 	<artifactId>org.eclipse.gemoc.gemoc_studio.root</artifactId>
 	<name>gemoc-studio root with tycho</name>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>gemoc_studio-eclipse-bom</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
 	</parent>
 	


### PR DESCRIPTION
## Description

Bump GEMOC Studio version to 3.5.0

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/212
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/64
 - https://github.com/eclipse/gemoc-studio-moccml/pull/22
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/51
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/22
