### PR TITLE
Bump eclipse 2021 12

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.2.0</version>
+    <version>2.6.0</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.6.0</version>
+    <version>2.5.0</version>
   </extension>
 </extensions>

--- a/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
+++ b/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
@@ -33,7 +33,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.deploy.skip>true</maven.deploy.skip>
 		
-		<tycho-version>2.6.0</tycho-version>
+		<tycho-version>2.5.0</tycho-version>
     	<xtend.version>2.25.0</xtend.version>
     	
     	<eclipse.release.p2.url>http://download.eclipse.org/releases/2021-12</eclipse.release.p2.url>

--- a/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
+++ b/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
@@ -33,10 +33,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.deploy.skip>true</maven.deploy.skip>
 		
-		<tycho-version>2.2.0</tycho-version>
+		<tycho-version>2.6.0</tycho-version>
     	<xtend.version>2.25.0</xtend.version>
     	
-    	<eclipse.release.p2.url>http://download.eclipse.org/releases/2021-06</eclipse.release.p2.url>
+    	<eclipse.release.p2.url>http://download.eclipse.org/releases/2021-12</eclipse.release.p2.url>
         <!--used only for amalgam which seems REALLY deprecated-->
         <eclipse.photon.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.photon.release.p2.url>
 		<k3.p2.url>http://www.kermeta.org/k3/update</k3.p2.url>

--- a/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
+++ b/gemoc_studio/plugins/org.eclipse.gemoc.gemoc_studio.branding/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<properties>
-		<eclipse.version.name>2021-06</eclipse.version.name>
+		<eclipse.version.name>2021-12</eclipse.version.name>
 		<!-- override these values using -D option on the maven command line on the CI (see jenkinsfile for CI configuration)-->		
 		<studio.variant>Local build</studio.variant>
 		<branch.variant>Unknown</branch.variant>

--- a/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
+++ b/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
@@ -48,8 +48,8 @@
 		<emf.compare-version>[3.4.0,3.6.0)</emf.compare-version>
 		<emf.transaction-version>[1.9.0,2.0.0)</emf.transaction-version> 
 		
-		<xtext-version>2.24.0</xtext-version>
-		<xtend-version>2.24.0</xtend-version>
+		<xtext-version>2.25.0</xtext-version>
+		<xtend-version>2.25.0</xtend-version>
 		
 	</properties>
 	<dependencyManagement>


### PR DESCRIPTION
## Description

Bump Eclipse base IDE to 2021-12
use corresponding tycho (2.5.0) and xtend/xtext (2.25.0)


## Companion Pull Requests

- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/213
- https://github.com/eclipse/gemoc-studio-execution-java/pull/23
- https://github.com/eclipse/gemoc-studio-execution-ale/pull/52
- https://github.com/eclipse/gemoc-studio-moccml/pull/23
- https://github.com/eclipse/gemoc-studio-execution-moccml/pull/65
