### PR TITLE
Make K3FSM semantics work with null input/outputs

### DIFF
--- a/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.k3dsa/src/org/eclipse/gemoc/example/k3fsm/k3dsa/k3fsmAspects.xtend
+++ b/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.k3dsa/src/org/eclipse/gemoc/example/k3fsm/k3dsa/k3fsmAspects.xtend
@@ -15,7 +15,7 @@ import static extension org.eclipse.gemoc.example.k3fsm.k3dsa.TransitionAspect.*
 @Aspect(className=FSM)
 class FSMAspect {
 	@Step
-	@InitializeModel
+	@InitializeModel									// <1>
 	def void initializeModel(EList<String> args) {
 		_self.currentState = _self.initialState;
 		_self.unprocessedString = args.get(0)
@@ -27,7 +27,7 @@ class FSMAspect {
 	}
 
 	@Step
-	@Main
+	@Main												// <2>
 	def void main() {
 		try {
 			while (!_self.unprocessedString.isEmpty) {
@@ -44,7 +44,7 @@ class FSMAspect {
 
 @Aspect(className=State)
 class StateAspect {
-	@Step
+	@Step												// <3>
 	def void step(String inputString) {
 		// Get the valid transitions	
 		val validTransitions = _self.outgoingTransitions.filter[t|t.input === null || inputString.startsWith(t.input)]
@@ -63,7 +63,7 @@ class StateAspect {
 @Aspect(className=Transition)
 class TransitionAspect {
 
-	@Step
+	@Step												// <4>
 	def void fire() {
 		println("Firing " + _self.name + " and entering " + _self.target.name)
 		val fsm = _self.source.owningFSM

--- a/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.k3dsa/src/org/eclipse/gemoc/example/k3fsm/k3dsa/k3fsmAspects.xtend
+++ b/official_samples/K3FSM/language_workbench/org.eclipse.gemoc.example.k3fsm.k3dsa/src/org/eclipse/gemoc/example/k3fsm/k3dsa/k3fsmAspects.xtend
@@ -4,56 +4,56 @@ import fr.inria.diverse.k3.al.annotationprocessor.Aspect
 import fr.inria.diverse.k3.al.annotationprocessor.InitializeModel
 import fr.inria.diverse.k3.al.annotationprocessor.Main
 import fr.inria.diverse.k3.al.annotationprocessor.Step
+import org.eclipse.emf.common.util.EList
 import org.eclipse.gemoc.example.k3fsm.FSM
 import org.eclipse.gemoc.example.k3fsm.State
 import org.eclipse.gemoc.example.k3fsm.Transition
-import org.eclipse.emf.common.util.EList
-	
+
+import static extension org.eclipse.gemoc.example.k3fsm.k3dsa.StateAspect.*
 import static extension org.eclipse.gemoc.example.k3fsm.k3dsa.TransitionAspect.*
-//import static extension org.eclipse.gemoc.example.k3fsm.k3dsa.FSMAspect.*			
-import static extension org.eclipse.gemoc.example.k3fsm.k3dsa.StateAspect.*			
 
 @Aspect(className=FSM)
 class FSMAspect {
-	@Step 												
-	@InitializeModel									// <1>
-	def void initializeModel(EList<String> args){
+	@Step
+	@InitializeModel
+	def void initializeModel(EList<String> args) {
 		_self.currentState = _self.initialState;
-		_self.unprocessedString = args.get(0)	
+		_self.unprocessedString = args.get(0)
 		_self.consummedString = ""
 		_self.producedString = ""
-		if(_self.unprocessedString.isEmpty) {
+		if (_self.unprocessedString.isEmpty) {
 			println("nothing to process, did you forgot to pass parameters to the launch configuration ?")
 		}
 	}
-	@Step	
-	@Main												// <2>
+
+	@Step
+	@Main
 	def void main() {
-    	try {
-    		while (!_self.unprocessedString.isEmpty) {
-    			_self.currentState.step(_self.unprocessedString)
-    		}    		
-		} catch (FSMRuntimeException nt){
-			println("Stopped due to "+nt.message)
+		try {
+			while (!_self.unprocessedString.isEmpty) {
+				_self.currentState.step(_self.unprocessedString)
+			}
+		} catch (FSMRuntimeException nt) {
+			println("Stopped due to " + nt.message)
 		}
-		println("unprocessed string: "+_self.unprocessedString)
-		println("processed string: "+_self.consummedString)
-		println("produced string: "+_self.producedString)
+		println("unprocessed string: " + _self.unprocessedString)
+		println("processed string: " + _self.consummedString)
+		println("produced string: " + _self.producedString)
 	}
 }
 
 @Aspect(className=State)
 class StateAspect {
-	@Step												// <3>
+	@Step
 	def void step(String inputString) {
 		// Get the valid transitions	
-		val validTransitions =  _self.outgoingTransitions.filter[t | inputString.startsWith(t.input)]
-		if(validTransitions.empty) {
+		val validTransitions = _self.outgoingTransitions.filter[t|t.input === null || inputString.startsWith(t.input)]
+		if (validTransitions.empty) {
 			throw new FSMRuntimeException("No Transition")
 		}
-		if(validTransitions.size > 1) {
+		if (validTransitions.size > 1) {
 			throw new FSMRuntimeException("Non Determinism")
-			
+
 		}
 		// Fire transition		
 		validTransitions.get(0).fire()
@@ -62,22 +62,20 @@ class StateAspect {
 
 @Aspect(className=Transition)
 class TransitionAspect {
-	
-	@Step												// <4>
+
+	@Step
 	def void fire() {
 		println("Firing " + _self.name + " and entering " + _self.target.name)
 		val fsm = _self.source.owningFSM
 		fsm.currentState = _self.target
-		fsm.producedString = fsm.producedString + _self.output
-		fsm.consummedString = fsm.consummedString + _self.input
-		fsm.unprocessedString = fsm.unprocessedString.substring(_self.input.length)
+		fsm.producedString = fsm.producedString + (_self.output !== null ? _self.output : "")
+		fsm.consummedString = fsm.consummedString + (_self.input !== null ? _self.input : "")
+		fsm.unprocessedString = fsm.unprocessedString.substring(_self.input !== null ? _self.input.length : 0)
 	}
 }
 
 class FSMRuntimeException extends Exception {
 	new(String message) {
 		super(message)
-	}				
+	}
 }
-
-


### PR DESCRIPTION
## Description

Currently, the semantics of K3FSM can only execute models where all transitions have both an input and an output string.

This PR solves that, and will make sure the semantics can legally fire a transition that has no input string.


## Changes

- Add new condition to consider a transition to be "valid" : `t.input === null`
- Adapt code to the fact that `input` and `output` may be `null`
- Reformat k3fsm semantics file