### PR TITLE
Use tpd for defining target platform

### DIFF
--- a/gemoc_studio/pom.xml
+++ b/gemoc_studio/pom.xml
@@ -140,6 +140,14 @@
 						<artifactId>target-platform-configuration</artifactId>
 						<version>${tycho-version}</version>
 						<configuration>
+							<target>
+		                        <artifact>
+		                            <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+		                            <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+		                            <version>3.5.0-SNAPSHOT</version>
+		                            <classifier>gemoc_studio</classifier>
+		                        </artifact>
+		                    </target>
 							<!-- environments that will be built in test mode -->
 							<environments>
 								<environment>
@@ -176,6 +184,14 @@
 						<artifactId>target-platform-configuration</artifactId>
 						<version>${tycho-version}</version>
 						<configuration>
+							<target>
+		                        <artifact>
+		                            <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+		                            <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+		                            <version>3.5.0-SNAPSHOT</version>
+		                            <classifier>gemoc_studio</classifier>
+		                        </artifact>
+		                    </target>
 							<!-- environments that will be built in test mode -->
 							<environments>
 								<environment>

--- a/gemoc_studio/pom.xml
+++ b/gemoc_studio/pom.xml
@@ -31,6 +31,7 @@
 		<module>releng/org.eclipse.gemoc.gemoc_studio.branding.feature</module>
 		<module>releng/org.eclipse.gemoc.gemoc_studio.additions.feature</module>
 		<module>releng/org.eclipse.gemoc.gemoc_studio.updatesite</module>
+		<module>releng/org.eclipse.gemoc.gemoc_studio.targetplatform</module>
 
 		<!-- modules required by modeling workbench tests platform -->
 		<module>../official_samples/K3FSM/language_workbench</module>
@@ -45,67 +46,16 @@
 	</modules>
 
 	<repositories>
-		<repository>
-			<id>Eclipse release</id>
-			<layout>p2</layout>
-			<url>${eclipse.release.p2.url}</url>
-		</repository>
-        <repository>
-			<!-- used by branding due to amalgam discovery -->
-			<id>Eclipse Photon release</id>
-			<layout>p2</layout>
-			<url>${eclipse.photon.release.p2.url}</url>
-		</repository>
+
 		<repository>
 			<id>K3</id>
 			<layout>p2</layout>
 			<url>${k3.p2.url}</url>
 		</repository>
 		<repository>
-			<id>ALE</id>
-			<layout>p2</layout>
-			<url>${ale.p2.url}</url>
-		</repository>
-		<repository>
 			<id>Melange</id>
 			<layout>p2</layout>
 			<url>${melange.p2.url}</url>
-		</repository>
-		<repository>
-			<id>timesquare</id>
-			<layout>p2</layout>
-			<url>${timesquare.p2.url}</url>
-		</repository>
-		<repository>
-			<id>diverse-commons</id>
-			<layout>p2</layout>
-			<url>${diverse-commons.p2.url}</url>
-		</repository>
-		<repository>
-			<id>ELK</id>
-			<layout>p2</layout>
-			<url>${elk.p2.url}</url>
-		</repository>
-		<repository>
-			<id>Sirius</id>
-			<layout>p2</layout>
-			<url>${sirius.p2.url}</url>
-		</repository>
-		<repository>
-			<id>AspectJ</id>
-			<layout>p2</layout>
-			<url>${aspectJ.p2.url}</url>
-		</repository>
-		<!--  e(fxc)lipse updatesite is currently required because they dropped from the release train -->
-		<repository>
-			<id>efxclipse</id>
-			<layout>p2</layout>
-			<url>${efxclipse.p2.url}</url>
-		</repository>
-        <repository>
-			<id>efxclipse2</id>
-			<layout>p2</layout>
-			<url>${efxclipse2.p2.url}</url>
 		</repository>
 	</repositories>
 
@@ -131,6 +81,14 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+					<target>
+                        <artifact>
+                            <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+                            <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+                            <version>3.5.0-SNAPSHOT</version>
+                            <classifier>gemoc_studio</classifier>
+                        </artifact>
+                    </target>
 					<!-- environments that will be built -->
 					<environments>
 						<environment>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
@@ -71,13 +71,12 @@ http://www.eclipse.org/legal/epl-v10.html
       <import feature="org.eclipse.ecf.core.feature.source" version="1.4.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.ecf.core.ssl.feature.source" version="1.1.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.ecf.filetransfer.feature.source" version="3.13.7" match="greaterOrEqual"/>
-      <import feature="org.eclipse.ecf.filetransfer.httpclient4.feature.source" version="3.13.7" match="greaterOrEqual"/>
-      <import feature="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.source" version="1.1.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.ecf.filetransfer.httpclient45.feature.source" version="1.1.0" match="greaterOrEqual"/>
+      <!--<import feature="org.eclipse.ecf.filetransfer.httpclient45.ssl.feature.source" version="1.1.0" match="greaterOrEqual"/>-->
       <import feature="org.eclipse.ecf.filetransfer.ssl.feature.source" version="1.1.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.ecoretools.registration.feature" version="3.3.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.query.sdk" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.compare" version="2.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.emf.compare.source" version="2.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.compare.ide.ui" version="2.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.diffmerge.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.diffmerge.gmf.feature" version="0.0.0" match="greaterOrEqual"/>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/.project
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.gemoc.gemoc_studio.targetplatform</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/.settings/org.eclipse.core.resources.prefs
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/README.md
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/README.md
@@ -1,0 +1,9 @@
+Please install TP DSL to edit the nablab.tpd file
+
+Source/User guide:
+https://github.com/eclipse-cbi/targetplatform-dsl
+
+Update-site:
+http://download.eclipse.org/cbi/tpd/3.0.0-SNAPSHOT/
+
+Never edit the nablab.target directly, generate it from the nablab.tpd (right-click on the file -> Create Target Definition File)

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde?>
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+<target name="GEMOCStudio Target platform" sequenceNumber="1643819825">
+  <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.acceleo.feature.group" version="3.7.11.202102190929"/>
+      <unit id="org.eclipse.e4.rcp.feature.group" version="4.22.0.v20211123-0851"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1800.v20210618-0642"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient45.feature.feature.group" version="1.1.0.v20211008-2034"/>
+      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.401.v20210409-2301"/>
+      <unit id="org.eclipse.egit.feature.group" version="6.0.0.202111291000-r"/>
+      <unit id="org.eclipse.emf.feature.group" version="2.28.0.v20211110-0654"/>
+      <unit id="org.eclipse.emf.compare.feature.group" version="3.3.17.202111290942"/>
+      <unit id="org.eclipse.emf.compare.rcp" version="2.5.2.202111290942"/>
+      <unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.3.17.202111290942"/>
+      <unit id="org.eclipse.emf.ecoretools.sdk.feature.group" version="3.3.4.202111191450"/>
+      <unit id="org.eclipse.emf.mwe2.runtime.sdk.feature.group" version="2.12.1.v20210218-2134"/>
+      <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="2.12.1.v20210218-2134"/>
+      <unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="2.12.1.v20210218-2134"/>
+      <unit id="org.eclipse.emf.query.sdk.feature.group" version="1.12.0.201805030653"/>
+      <unit id="org.eclipse.epp.mpc.feature.group" version="1.9.2.v20210826-0851"/>
+      <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.11.1400.v20211104-1616"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1400.v20211117-0650"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.19.0.20211116-0804"/>
+      <unit id="org.eclipse.m2e.logback.feature.feature.group" version="1.17.2.20211002-1029"/>
+      <unit id="org.eclipse.m2m.qvt.oml.feature.group" version="3.10.5.v20211130-1509"/>
+      <unit id="org.eclipse.m2m.qvt.oml.editor.feature.group" version="3.10.5.v20211130-1509"/>
+      <unit id="org.eclipse.m2m.qvt.oml.runtime.feature.group" version="3.10.5.v20211130-1509"/>
+      <unit id="org.eclipse.m2m.qvt.oml.sdk.feature.group" version="3.10.5.v20211130-1509"/>
+      <unit id="org.eclipse.ocl.examples.feature.group" version="6.17.0.v20211130-1448"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.22.0.v20211124-1800"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.22.0.v20211124-1800"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="3.1.0.202106041005"/>
+      <unit id="org.eclipse.swtbot.ide.feature.group" version="3.1.0.202106041005"/>
+      <unit id="org.eclipse.swtbot.feature.group" version="3.1.0.202106041005"/>
+      <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.24.0.v202110010323"/>
+      <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.24.0.v202111190506"/>
+      <unit id="org.eclipse.xtext.sdk.feature.group" version="2.25.0.v20210301-1429"/>
+      <unit id="org.eclipse.xtend.sdk.feature.group" version="2.25.0.v20210301-1429"/>
+      <unit id="ch.qos.logback.classic" version="1.2.3.v20200428-2012"/>
+      <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
+      <unit id="org.apache.xalan" version="2.7.2.v20201124-1837"/>
+      <repository id="eclipse" location="https://download.eclipse.org/releases/2021-12"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.sirius.specifier.feature.group" version="6.5.1.202106111115"/>
+      <unit id="org.eclipse.sirius.aql.feature.group" version="6.5.1.202106111115"/>
+      <unit id="org.eclipse.sirius.runtime.feature.group" version="6.5.1.202106111115"/>
+      <unit id="org.eclipse.sirius.runtime.aql.feature.group" version="6.5.1.202106111115"/>
+      <unit id="org.eclipse.sirius.runtime.ocl.feature.group" version="6.5.1.202106111115"/>
+      <unit id="org.eclipse.sirius.runtime.ide.ui.feature.group" version="6.5.1.202106111115"/>
+      <unit id="org.eclipse.sirius.runtime.ide.eef.feature.group" version="6.5.1.202106111115"/>
+      <unit id="org.eclipse.sirius.runtime.ide.xtext.feature.group" version="6.5.1.202106111115"/>
+      <unit id="org.eclipse.sirius.properties.feature.feature.group" version="6.5.1.202106111115"/>
+      <unit id="org.eclipse.eef.sdk.feature.feature.group" version="2.1.5.202008270808"/>
+      <unit id="org.eclipse.eef.ext.widgets.reference.feature.feature.group" version="2.1.5.202008270808"/>
+      <unit id="org.eclipse.sirius.diagram.elk.feature.feature.group" version="6.5.1.202106111115"/>
+      <repository id="sirius" location="https://download.eclipse.org/sirius/updates/releases/6.5.1/2020-09/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.amalgam.discovery.feature.group" version="1.8.0.201706011309"/>
+      <repository id="photon" location="http://download.eclipse.org/releases/photon"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.emf.diffmerge.feature.feature.group" version="0.13.0.202010211615"/>
+      <unit id="org.eclipse.emf.diffmerge.gmf.feature.feature.group" version="0.13.0.202010211615"/>
+      <unit id="org.eclipse.emf.diffmerge.sirius.feature.feature.group" version="0.13.0.202010211615"/>
+      <unit id="org.eclipse.emf.diffmerge.egit.feature.feature.group" version="0.13.0.202010211615"/>
+      <repository id="diffmerge" location="http://download.eclipse.org/diffmerge/releases/0.13.0/emf-diffmerge-site"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.emf.ecoretools.ale.feature.feature.group" version="1.2.0.202007171516"/>
+      <repository id="ale" location="http://www.kermeta.org/ale-lang/updates/2020-07-17"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.ajdt.feature.group" version="2.2.4.202201251622"/>
+      <repository id="ajdt" location="http://download.eclipse.org/tools/ajdt/410/dev/update"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="fr.inria.aoste.timesquare.feature.feature.group" version="1.0.0.202109021545"/>
+      <repository id="timesquare" location="http://timesquare.inria.fr/update_site/2020"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.emf.ecoretools.registration.feature.feature.group" version="3.3.0.201811051325"/>
+      <repository id="diverse-commons" location="http://www.kermeta.org/diverse-commons/updates/latest"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="openjfx.standard.feature.feature.group" version="11.0.0.201901231300"/>
+      <unit id="openjfx.swing.feature.feature.group" version="11.0.0.201901231300"/>
+      <unit id="openjfx.swt.feature.feature.group" version="11.0.0.201901231300"/>
+      <unit id="openjfx.media.feature.feature.group" version="11.0.0.201901231300"/>
+      <unit id="openjfx.web.feature.feature.group" version="11.0.0.201901231300"/>
+      <repository id="openjfx" location="https://downloads.efxclipse.bestsolution.at/p2-repos/openjfx-11/repository/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.fx.ide.basic.feature.feature.group" version="3.7.0.202010120832"/>
+      <unit id="org.eclipse.fx.ide.pde.feature.feature.group" version="3.7.0.202010120832"/>
+      <unit id="org.eclipse.fx.runtime.min.feature.feature.group" version="3.7.0.202010120826"/>
+      <repository id="fxclipse" location="https://download.eclipse.org/efxclipse/updates-released/3.7.0/site"/>
+    </location>
+  </locations>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+</target>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.tpd
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.tpd
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Inria
+ * This program and the accompanying materials are made available under the 
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * Contributors: see AUTHORS file
+ *******************************************************************************/
+target "GEMOCStudio Target platform"
+
+with source requirements
+environment JavaSE-11
+
+location eclipse "https://download.eclipse.org/releases/2021-12" {
+	// features
+	org.eclipse.acceleo.feature.group
+	org.eclipse.e4.rcp.feature.group
+	org.eclipse.ecf.filetransfer.feature.feature.group
+	org.eclipse.ecf.filetransfer.httpclient45.feature.feature.group
+	org.eclipse.ecf.filetransfer.ssl.feature.feature.group
+	org.eclipse.egit.feature.group
+	org.eclipse.emf.feature.group
+	org.eclipse.emf.compare.feature.group
+	org.eclipse.emf.compare.rcp
+	org.eclipse.emf.compare.ide.ui.feature.group
+	org.eclipse.emf.ecoretools.sdk.feature.group
+	org.eclipse.emf.mwe2.runtime.sdk.feature.group
+	org.eclipse.emf.mwe2.launcher.feature.group
+	org.eclipse.emf.mwe2.language.sdk.feature.group
+	org.eclipse.emf.query.sdk.feature.group
+	org.eclipse.epp.mpc.feature.group
+	org.eclipse.equinox.p2.sdk.feature.group
+	org.eclipse.equinox.executable.feature.group
+	org.eclipse.m2e.feature.feature.group
+	org.eclipse.m2e.logback.feature.feature.group
+	org.eclipse.m2m.qvt.oml.feature.group
+	org.eclipse.m2m.qvt.oml.editor.feature.group
+	org.eclipse.m2m.qvt.oml.runtime.feature.group
+	org.eclipse.m2m.qvt.oml.sdk.feature.group
+	org.eclipse.ocl.examples.feature.group
+	//org.eclipse.cdt.feature.group
+	org.eclipse.rcp.feature.group
+	org.eclipse.sdk.feature.group
+	org.eclipse.swtbot.eclipse.feature.group
+	org.eclipse.swtbot.ide.feature.group
+	org.eclipse.swtbot.feature.group
+	org.eclipse.wst.xml_core.feature.feature.group
+	org.eclipse.wst.xml_ui.feature.feature.group
+	org.eclipse.xtext.sdk.feature.group
+	org.eclipse.xtend.sdk.feature.group
+	// individual plugins
+	ch.qos.logback.classic
+	org.apache.commons.lang3
+	org.apache.xalan
+
+
+}
+
+location sirius "https://download.eclipse.org/sirius/updates/releases/6.5.1/2020-09/" {
+	org.eclipse.sirius.specifier.feature.group
+	org.eclipse.sirius.aql.feature.group
+	org.eclipse.sirius.runtime.feature.group
+	org.eclipse.sirius.runtime.aql.feature.group
+	org.eclipse.sirius.runtime.ocl.feature.group
+	org.eclipse.sirius.runtime.ide.ui.feature.group
+	org.eclipse.sirius.runtime.ide.eef.feature.group
+	org.eclipse.sirius.runtime.ide.xtext.feature.group
+	org.eclipse.sirius.properties.feature.feature.group
+	org.eclipse.eef.sdk.feature.feature.group
+	org.eclipse.eef.ext.widgets.reference.feature.feature.group
+	org.eclipse.sirius.diagram.elk.feature.feature.group
+}
+
+/* required due to amalgam discovery */
+location photon "http://download.eclipse.org/releases/photon" {
+	org.eclipse.amalgam.discovery.feature.group
+}
+
+location diffmerge "http://download.eclipse.org/diffmerge/releases/0.13.0/emf-diffmerge-site" {
+	org.eclipse.emf.diffmerge.feature.feature.group
+	org.eclipse.emf.diffmerge.gmf.feature.feature.group
+	org.eclipse.emf.diffmerge.sirius.feature.feature.group
+	org.eclipse.emf.diffmerge.egit.feature.feature.group
+}
+
+//location k3 "http://www.kermeta.org/k3/update" {
+//	fr.inria.diverse.k3.feature.feature.group
+//	//org.eclipse.gemoc.commons.eclipse.feature.feature.group
+//}
+//
+//location gemoc_dsl_bootstrap "http://download.eclipse.org/gemoc/updates/releases/3.4.0" {
+//	org.eclipse.gemoc.dsl
+//	org.eclipse.gemoc.dsl.model
+//}
+
+location ale "http://www.kermeta.org/ale-lang/updates/2020-07-17" {
+	org.eclipse.emf.ecoretools.ale.feature.feature.group
+}
+
+//location elk "http://melange.inria.fr/updatesite/nightly/update_2020-11-16" {
+//	fr.inria.diverse.melange.sdk.feature.group
+//	
+//}
+
+location ajdt "http://download.eclipse.org/tools/ajdt/410/dev/update" {
+	org.eclipse.ajdt.feature.group
+}
+
+location timesquare "http://timesquare.inria.fr/update_site/2020" {
+	fr.inria.aoste.timesquare.feature.feature.group
+}
+
+location diverse-commons "http://www.kermeta.org/diverse-commons/updates/latest" {
+	org.eclipse.emf.ecoretools.registration.feature.feature.group
+}
+
+location openjfx "https://downloads.efxclipse.bestsolution.at/p2-repos/openjfx-11/repository/" {
+	openjfx.standard.feature.feature.group
+	openjfx.swing.feature.feature.group
+	openjfx.swt.feature.feature.group
+	openjfx.media.feature.feature.group
+	openjfx.web.feature.feature.group
+}
+
+location fxclipse "https://download.eclipse.org/efxclipse/updates-released/3.7.0/site" {
+	org.eclipse.fx.ide.basic.feature.feature.group
+	org.eclipse.fx.ide.pde.feature.feature.group
+	org.eclipse.fx.runtime.min.feature.feature.group
+}
+
+

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/pom.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+        <artifactId>org.eclipse.gemoc.gemoc_studio.parent</artifactId>
+        <version>3.5.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+    <version>3.5.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+</project>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
@@ -151,78 +151,40 @@
 			   <groupId>org.eclipse.tycho</groupId>
 			   <artifactId>target-platform-configuration</artifactId>
 			   <version>${tycho-version}</version>
-			   <configuration>
-			      <dependency-resolution>
-			         <extraRequirements>
-			         	<!-- Eclipse platform -->
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.e4.rcp</id>
-			               <versionRange>4.18.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.sdk</id>
-			               <versionRange>4.18.0</versionRange>
-			            </requirement>
-			            <!-- avoid debug message from git -->
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.jgit</id>
-			               <versionRange>5.10.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.egit</id>
-			               <versionRange>5.10.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.pde</id>
-			               <versionRange>3.14.0</versionRange>
-			            </requirement>
-			            <!-- GEMOC components -->
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.gemoc.modeldebugging.feature</id>
-			               <versionRange>3.1.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.gemoc.gemoc_studio.branding.feature</id>
-			               <versionRange>3.1.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.gemoc.gemoc_studio.additions.feature</id>
-			               <versionRange>3.1.0</versionRange>
-			            </requirement>
-			            <!-- SWTBot features -->
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.swtbot</id>
-			               <versionRange>3.0.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.swtbot.eclipse</id>
-			               <versionRange>3.0.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.swtbot.ide</id>
-			               <versionRange>3.0.0</versionRange>
-			            </requirement>
-			            
-			            <requirement>
-			               <type>eclipse-plugin</type>
-			               <id>org.eclipse.gemoc.studio.tests.logging.config</id>
-			               <versionRange>0.0.0</versionRange>
-			            </requirement>
-			         </extraRequirements>
-			        
-			      </dependency-resolution>
-			   </configuration>
+				<configuration>
+					<target>
+						<artifact>
+		                    <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+		                    <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+		                    <version>3.5.0-SNAPSHOT</version>
+		                    <classifier>gemoc_studio</classifier>
+		                </artifact>
+	                </target>
+				      <dependency-resolution>
+				         <extraRequirements>
+				           <requirement>
+				               <type>eclipse-feature</type>
+				               <id>org.eclipse.gemoc.modeldebugging.feature</id>
+				               <versionRange>3.1.0</versionRange>
+				            </requirement>
+				            <requirement>
+				               <type>eclipse-feature</type>
+				               <id>org.eclipse.gemoc.gemoc_studio.branding.feature</id>
+				               <versionRange>3.1.0</versionRange>
+				            </requirement>
+				            <requirement>
+				               <type>eclipse-feature</type>
+				               <id>org.eclipse.gemoc.gemoc_studio.additions.feature</id>
+				               <versionRange>3.1.0</versionRange>
+				            </requirement>
+				            <requirement>
+				               <type>eclipse-plugin</type>
+				               <id>org.eclipse.gemoc.studio.tests.logging.config</id>
+				               <versionRange>0.0.0</versionRange>
+				            </requirement>
+				         </extraRequirements>
+				      </dependency-resolution>
+				</configuration>
 			</plugin>
 			<plugin>
     			<artifactId>maven-clean-plugin</artifactId>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
@@ -45,7 +45,8 @@
 					<argLine>-Xmx1500m</argLine>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
-					<product>org.eclipse.sdk.ide</product>
+					<!-- <product>org.eclipse.sdk.ide</product>-->
+					<product>org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio</product>
               		<application>org.eclipse.ui.ide.workbench</application>
               		<testFailureIgnore>true</testFailureIgnore> <!-- failed tests here must fail the build-->
               		<systemProperties>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/pom.xml
@@ -45,7 +45,7 @@
 					<argLine>-Xmx1500m</argLine>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
-					<!-- <product>org.eclipse.sdk.ide</product>-->
+					<testRuntime>p2Installed</testRuntime><!-- install the full gemoc_studio product  cf. extraRequirements section -->
 					<product>org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio</product>
               		<application>org.eclipse.ui.ide.workbench</application>
               		<testFailureIgnore>true</testFailureIgnore> <!-- failed tests here must fail the build-->
@@ -163,24 +163,15 @@
 	                </target>
 				      <dependency-resolution>
 				         <extraRequirements>
-				           <requirement>
-				               <type>eclipse-feature</type>
-				               <id>org.eclipse.gemoc.modeldebugging.feature</id>
-				               <versionRange>3.1.0</versionRange>
-				            </requirement>
-				            <requirement>
-				               <type>eclipse-feature</type>
-				               <id>org.eclipse.gemoc.gemoc_studio.branding.feature</id>
-				               <versionRange>3.1.0</versionRange>
-				            </requirement>
-				            <requirement>
-				               <type>eclipse-feature</type>
-				               <id>org.eclipse.gemoc.gemoc_studio.additions.feature</id>
-				               <versionRange>3.1.0</versionRange>
-				            </requirement>
 				            <requirement>
 				               <type>eclipse-plugin</type>
 				               <id>org.eclipse.gemoc.studio.tests.logging.config</id>
+				               <versionRange>0.0.0</versionRange>
+				            </requirement>
+							<!-- product IU under test -->
+				            <requirement>
+				               <type>p2-installable-unit</type>
+				               <id>gemoc_studio</id>
 				               <versionRange>0.0.0</versionRange>
 				            </requirement>
 				         </extraRequirements>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
@@ -99,64 +99,44 @@
 				</executions>
 			</plugin>
 			<plugin>
-			   <groupId>org.eclipse.tycho</groupId>
-			   <artifactId>target-platform-configuration</artifactId>
-			   <version>${tycho-version}</version>
-			   <configuration>
-			      <dependency-resolution>
-			         <extraRequirements>
-			         	<!-- Eclipse platform -->
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.e4.rcp</id>
-			               <versionRange>4.18.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.sdk</id>
-			               <versionRange>4.18.0</versionRange>
-			            </requirement>
-			            <!-- GEMOC components -->
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.gemoc.modeldebugging.feature</id>
-			               <versionRange>3.1.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.gemoc.gemoc_studio.branding.feature</id>
-			               <versionRange>3.1.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.gemoc.gemoc_studio.additions.feature</id>
-			               <versionRange>3.1.0</versionRange>
-			            </requirement>
-			            <!-- SWTBot features -->
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.swtbot</id>
-			               <versionRange>3.0.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.swtbot.eclipse</id>
-			               <versionRange>3.0.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-feature</type>
-			               <id>org.eclipse.swtbot.ide</id>
-			               <versionRange>3.0.0</versionRange>
-			            </requirement>
-			            <requirement>
-			               <type>eclipse-plugin</type>
-			               <id>org.eclipse.gemoc.studio.tests.logging.config</id>
-			               <versionRange>0.0.0</versionRange>
-			            </requirement>
-			         </extraRequirements>
-			        
-			      </dependency-resolution>
-			   </configuration>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<artifact>
+		                    <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+		                    <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+		                    <version>3.5.0-SNAPSHOT</version>
+		                    <classifier>gemoc_studio</classifier>
+		                </artifact>
+	                </target>
+				      <dependency-resolution>
+				         <extraRequirements>
+				           <requirement>
+				               <type>eclipse-feature</type>
+				               <id>org.eclipse.gemoc.modeldebugging.feature</id>
+				               <versionRange>3.1.0</versionRange>
+				            </requirement>
+				            <requirement>
+				               <type>eclipse-feature</type>
+				               <id>org.eclipse.gemoc.gemoc_studio.branding.feature</id>
+				               <versionRange>3.1.0</versionRange>
+				            </requirement>
+				            <requirement>
+				               <type>eclipse-feature</type>
+				               <id>org.eclipse.gemoc.gemoc_studio.additions.feature</id>
+				               <versionRange>3.1.0</versionRange>
+				            </requirement>
+				            <requirement>
+				               <type>eclipse-plugin</type>
+				               <id>org.eclipse.gemoc.studio.tests.logging.config</id>
+				               <versionRange>0.0.0</versionRange>
+				            </requirement>
+				         </extraRequirements>
+				        
+				      </dependency-resolution>
+				</configuration>
 			</plugin>
 			<plugin>
     			<artifactId>maven-clean-plugin</artifactId>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
@@ -45,7 +45,8 @@
 					<argLine>-Xmx1500m</argLine>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
-					<product>org.eclipse.sdk.ide</product>
+					<!-- <product>org.eclipse.sdk.ide</product>-->
+					<product>org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio</product>
               		<application>org.eclipse.ui.ide.workbench</application>
               		<testFailureIgnore>true</testFailureIgnore> <!-- failed tests here must fail the build-->
               		<systemProperties>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/pom.xml
@@ -45,7 +45,8 @@
 					<argLine>-Xmx1500m</argLine>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
-					<!-- <product>org.eclipse.sdk.ide</product>-->
+					<showEclipseLog>true</showEclipseLog>
+					<testRuntime>p2Installed</testRuntime><!-- install the full gemoc_studio product cf. extraRequirements section -->
 					<product>org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio</product>
               		<application>org.eclipse.ui.ide.workbench</application>
               		<testFailureIgnore>true</testFailureIgnore> <!-- failed tests here must fail the build-->
@@ -114,7 +115,7 @@
 	                </target>
 				      <dependency-resolution>
 				         <extraRequirements>
-				           <requirement>
+				          <!-- <requirement>
 				               <type>eclipse-feature</type>
 				               <id>org.eclipse.gemoc.modeldebugging.feature</id>
 				               <versionRange>3.1.0</versionRange>
@@ -128,10 +129,16 @@
 				               <type>eclipse-feature</type>
 				               <id>org.eclipse.gemoc.gemoc_studio.additions.feature</id>
 				               <versionRange>3.1.0</versionRange>
-				            </requirement>
+				            </requirement>-->
 				            <requirement>
 				               <type>eclipse-plugin</type>
 				               <id>org.eclipse.gemoc.studio.tests.logging.config</id>
+				               <versionRange>0.0.0</versionRange>
+				            </requirement>
+							<!-- product IU under test -->
+				            <requirement>
+				               <type>p2-installable-unit</type>
+				               <id>gemoc_studio</id>
 				               <versionRange>0.0.0</versionRange>
 				            </requirement>
 				         </extraRequirements>

--- a/official_samples/K3FSM/language_workbench/pom.xml
+++ b/official_samples/K3FSM/language_workbench/pom.xml
@@ -32,11 +32,6 @@
     </modules>
     <repositories>
 		<repository>
-			<id>Eclipse release</id>
-			<layout>p2</layout>
-			<url>${eclipse.release.p2.url}</url>
-		</repository>
-		<repository>
 			<id>K3</id>
 			<layout>p2</layout>
 			<url>${k3.p2.url}</url>

--- a/official_samples/sample.deployers/pom.xml
+++ b/official_samples/sample.deployers/pom.xml
@@ -29,11 +29,6 @@
         <module>releng/org.eclipse.gemoc.sequential.samples.deployers.feature</module>
     </modules>
 	<repositories>
-		<repository>
-			<id>Eclipse release</id>
-			<layout>p2</layout>
-			<url>${eclipse.release.p2.url}</url>
-		</repository>
 	</repositories>
 	
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,14 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+					<target>
+                        <artifact>
+                            <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+                            <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+                            <version>3.5.0-SNAPSHOT</version>
+                            <classifier>gemoc_studio</classifier>
+                        </artifact>
+                    </target>
 					<!-- environments that will be built -->
 					<environments>
 						<environment>


### PR DESCRIPTION
## Description
This PR changes the way the external update sites are imported in the build.
Instead of using maven repository like:
```
	<repositories>
		<repository>
			<id>Eclipse release</id>
			<layout>p2</layout>
			<url>${eclipse.release.p2.url}</url>
		</repository>
```
It uses a tpd description file in order to generate a targetplatform file.
This tpd allows to not specify precisely the version of the imported unit while helping to control where they come from.

A readme file explains how to update the target file from the tpd (in `gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform`)

NOTE: the use of the tpd is partial: the K3 and melange updatesite currently cannot be integrated in the target because these tools depends on gemoc.dsl that is actually build by GEMOC. This creates a kind of cycle in the targetplatfomr :disappointed: . Melange an K3 as thus still using the maven repository descriptor.

Additionally, the integration tests now explicitly use the gemoc product and target (this fix the javafx error preventing from opening the multidimentional view in the tests)

 :disappointed: I was expecting a speed up in the build (https://github.com/eclipse/gemoc-studio/issues/233) but, apparently, the newer version of tycho are optimized enough and there is no visible speed change.
 
## Contribution to issues

Contribute to https://github.com/eclipse/gemoc-studio/issues/233


## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/259
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/216
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/66
 - https://github.com/eclipse/gemoc-studio-moccml/pull/24
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/53
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/24
