### PR TITLE
Update target to latest and target generation script

### DIFF
--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/.gitignore
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/.gitignore
@@ -1,0 +1,2 @@
+/eclipse/
+/eclipse-platform-*.tar.gz

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/README.md
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/README.md
@@ -1,4 +1,4 @@
-Please install TP DSL to edit the nablab.tpd file
+Please install TP DSL to edit the `gemoc_studio.tpd` file
 
 Source/User guide:
 https://github.com/eclipse-cbi/targetplatform-dsl
@@ -6,4 +6,4 @@ https://github.com/eclipse-cbi/targetplatform-dsl
 Update-site:
 http://download.eclipse.org/cbi/tpd/3.0.0-SNAPSHOT/
 
-Never edit the nablab.target directly, generate it from the nablab.tpd (right-click on the file -> Create Target Definition File)
+Never edit the `gemoc_studio.target` directly, generate it from the `gemoc_studio.tpd` (right-click on the file -> Create Target Definition File)

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="GEMOCStudio Target platform" sequenceNumber="1643819825">
+<target name="GEMOCStudio Target platform" sequenceNumber="1646831631">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.acceleo.feature.group" version="3.7.11.202102190929"/>
@@ -74,7 +74,7 @@
       <repository id="ale" location="http://www.kermeta.org/ale-lang/updates/2020-07-17"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.ajdt.feature.group" version="2.2.4.202201251622"/>
+      <unit id="org.eclipse.ajdt.feature.group" version="2.2.4.202202111622"/>
       <repository id="ajdt" location="http://download.eclipse.org/tools/ajdt/410/dev/update"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/update_target.sh
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/update_target.sh
@@ -10,7 +10,7 @@ if [[ ! -d eclipse ]]
 then
   rm -rf $ECLIPSE_PLATFORM_ARCHIVE
   echo "Downloading eclipse platform..."
-  wget -O $ECLIPSE_PLATFORM_ARCHIVE  "$ECLIPSE_PLATFORM_URL" 
+  wget -nv -O $ECLIPSE_PLATFORM_ARCHIVE  "$ECLIPSE_PLATFORM_URL" 
 
   echo "Extracting eclipse platform..."
   tar -xzf $ECLIPSE_PLATFORM_ARCHIVE

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/update_target.sh
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/update_target.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#set -o xtrace
+
+export ECLIPSE_PLATFORM_ARCHIVE=eclipse-platform-4.22-linux-gtk-x86_64.tar.gz
+export ECLIPSE_PLATFORM_URL="https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.22-202111241800/eclipse-platform-4.22-linux-gtk-x86_64.tar.gz&r=1"
+
+
+if [[ ! -d eclipse ]]
+then
+  rm -rf $ECLIPSE_PLATFORM_ARCHIVE
+  echo "Downloading eclipse platform..."
+  wget -O $ECLIPSE_PLATFORM_ARCHIVE  "$ECLIPSE_PLATFORM_URL" 
+
+  echo "Extracting eclipse platform..."
+  tar -xzf $ECLIPSE_PLATFORM_ARCHIVE
+
+  echo "Installing TPD tool in eclipse platform..."
+  ./eclipse/eclipse -nosplash -application org.eclipse.equinox.p2.director \
+    -repository http://download.eclipse.org/cbi/tpd/3.0.0-SNAPSHOT/,http://download.eclipse.org/releases/2021-12/ \
+    -destination ./eclipse/ \
+    -installIU org.eclipse.cbi.targetplatform-feature.feature.group
+else
+   echo "Eclipse platform already installed, skipping platform download"
+fi
+
+echo "Updating gemoc_studio.target from gemoc_studio.tpd definition..."
+#use eclipse app to update the target
+./eclipse/eclipse -nosplash -application org.eclipse.cbi.targetplatform.tpd.converter gemoc_studio.tpd


### PR DESCRIPTION
## Description

Update the `gemoc_studio.target` to latest versions availble on internet

Add a script able to automate the generation of the `gemoc_studio.target`  from `gemoc_studio.tpd`

An update of the `jenkinsfile` is required to fully take advantage of this script. (in https://github.com/gemoc/gemoc-studio-eclipse-integration and https://github.com/gemoc/gemoc-studio-eclipseforks-integration)

## Contribution to issues

Closes https://github.com/eclipse/gemoc-studio/issues/262

