### PR TITLE
Apple m1 support

### DIFF
--- a/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/introduction_headContent.asciidoc
+++ b/docs/org.eclipse.gemoc.studio.doc/src/main/asciidoc/introduction_headContent.asciidoc
@@ -109,5 +109,18 @@ Animate models::
 [NOTE]
 .Note
 =====================================================================
-In order to run, Eclipse workbench work better with additional memory. Use the following setting to start Eclipse: -Xms1024m -Xmx1024m -XX:PermSize=512m -XX:MaxPermSize=512m
+In order to run, Eclipse workbench work better with additional memory. Use the following setting to start Eclipse: `-Xms1024m -Xmx1024m -XX:PermSize=512m -XX:MaxPermSize=512m`
+=====================================================================
+
+[NOTE]
+.Note
+=====================================================================
+As our package aren't digitically signed, Mac computer may prevent running the studio. To workaround this Mac limitation, you may try one of these actions:
+
+* Remove the quarantine status
+   ** Open a terminal in the folder containing the `.app`
+   ** Execute: `xattr -d com.apple.quarantine Eclipse.app`
+   ** Double clic the `.app`
+* Open a terminal and launch `./Eclipse.app/Contents/Eclipse/eclipse`
+
 =====================================================================

--- a/gemoc_studio/pom.xml
+++ b/gemoc_studio/pom.xml
@@ -108,6 +108,11 @@
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>aarch64</arch>
+						</environment>
 					</environments>
 				</configuration>
 			</plugin>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/src/main/filtered-resources/products/index.html
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/src/main/filtered-resources/products/index.html
@@ -201,9 +201,11 @@
           <div id='dirlist' style='display:inline;'><img src='https://dev.eclipse.org/small_icons/places/folder.png'><a href='/gemoc/packages/nightly/../?d'> ..</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-linux.gtk.x86_64.zip'> gemoc_studio-linux.gtk.x86_64.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-macosx.cocoa.x86_64.zip'> gemoc_studio-macosx.cocoa.x86_64.zip</a> <br />
+<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-macosx.cocoa.aarch64.zip'> gemoc_studio-macosx.cocoa.aarch64.zip</a> <br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-win32.win32.x86_64.zip'> gemoc_studio-win32.win32.x86_64.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-linux.gtk.x86_64.zip'> gemoc_studio_headless_engine_runner-linux.gtk.x86_64.zip</a><br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-macosx.cocoa.x86_64.zip'> gemoc_studio_headless_engine_runner-macosx.cocoa.x86_64.zip</a> <br />
+<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-macosx.cocoa.aarch64.zip'> gemoc_studio_headless_engine_runner-macosx.cocoa.aarch64.zip</a> <br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-win32.win32.x86_64.zip'> gemoc_studio_headless_engine_runner-win32.win32.x86_64.zip</a><br />
 </div><script language='javascript' src='/errors/js.js'></script>
           <h2>Other useful links</h2>


### PR DESCRIPTION
## Description

Add Apple M1 processor version of the GEMOC Studio.

This should enable some native execution rather than x86 emulation

## Changes

also add a note in the documentation about Apple application quarantine and how to workaround it.
 
## Contribution to issues

Closes https://github.com/eclipse/gemoc-studio/issues/267

