### PR TITLE
Split commons eclipse pde to remove UI dependency

### DIFF
--- a/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
+++ b/gemoc_studio/pomfirst/gemoc-studio-bom/pom.xml
@@ -47,6 +47,7 @@
 		<emf.ecore.xmi-version>2.16.0</emf.ecore.xmi-version>
 		<emf.compare-version>[3.4.0,3.6.0)</emf.compare-version>
 		<emf.transaction-version>[1.9.0,2.0.0)</emf.transaction-version> 
+		<jdt-version>3.30.0</jdt-version> 
 		
 		<xtext-version>2.25.0</xtext-version>
 		<xtend-version>2.25.0</xtend-version>
@@ -114,6 +115,11 @@
 			</dependency>
 
 
+			<dependency>
+			    <groupId>org.eclipse.jdt</groupId>
+			    <artifactId>org.eclipse.jdt.core</artifactId>
+				<version>${jdt-version}</version>
+			</dependency>
 			<dependency>
 				<groupId>org.eclipse.platform</groupId>
 				<artifactId>org.eclipse.core.expressions</artifactId>


### PR DESCRIPTION
## Description

Add support for pomfirst version of `org.eclipse.gemoc.commons.eclipse.pde`

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - https://github.com/eclipse/gemoc-studio-commons/pull/1
 - https://github.com/eclipse/gemoc-studio/pull/276
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/224
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/28
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/70
