### PR TITLE
Use fixed version of k3 to ensure reproducibility

### DIFF
--- a/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
+++ b/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
@@ -39,7 +39,7 @@
     	<eclipse.release.p2.url>http://download.eclipse.org/releases/2022-06</eclipse.release.p2.url>
         <!--used only for amalgam which seems REALLY deprecated-->
         <eclipse.photon.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.photon.release.p2.url>
-		<k3.p2.url>http://www.kermeta.org/k3/update</k3.p2.url>
+		<k3.p2.url>http://www.kermeta.org/k3/update_2022-09-08</k3.p2.url>
 		<ale.p2.url>http://www.kermeta.org/ale-lang/updates/2020-07-17</ale.p2.url>
 		<!-- <ale.p2.url>https://ci.inria.fr/gemoc/job/ale-lang/job/bump-to-eclipse-2020-03/lastSuccessfulBuild/artifact/releng/org.eclipse.emf.ecoretools.ale.updatesite/target/repository/</ale.p2.url>-->
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2022-09-29</melange.p2.url>

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateLangRuntime4OfficialExampleMelangeK3FSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/feature/GenerateLangRuntime4OfficialExampleMelangeK3FSM_Test.xtend
@@ -137,7 +137,10 @@ class GenerateLangRuntime4OfficialExampleMelangeK3FSM_Test extends AbstractXtext
 			}
 		])
 		thrownException.forall[e| throw new Exception(e)] // rethrown exception that was executed in the ui thread
+		
+		IResourcesSetupUtil::waitForBuild
 		IResourcesSetupUtil::reallyWaitForAutoBuild
+		WorkspaceTestHelper::reallyWaitForJobs(4)
 		helper.assertNoMarkers
 		
 		helper.assertProjectExists(PROJECT_NAME)

--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateMelangeBasedSingleSequentialLanguageFromOfficialFSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb/src/org/eclipse/gemoc/studio/tests/system/lwb/userstory/CreateMelangeBasedSingleSequentialLanguageFromOfficialFSM_Test.xtend
@@ -226,6 +226,7 @@ class CreateMelangeBasedSingleSequentialLanguageFromOfficialFSM_Test extends Abs
 		// Melange "Generate all is a bit special as it trigger several jobs one after the other
 		// retry in order to make sure they all have been done 
 		IResourcesSetupUtil::waitForBuild
+		IResourcesSetupUtil::reallyWaitForAutoBuild
 		WorkspaceTestHelper::reallyWaitForJobs(50)
 		//IResourcesSetupUtil::reallyWaitForAutoBuild
 		


### PR DESCRIPTION

## Description

use a fixed version of K3 instead of the _latest_   version that may change overtime and create reproducibility issues

## Changes

use current K3 version  (update_2022-09-08)
 
## Contribution to issues

This will prepare work for validating 
- https://github.com/eclipse/gemoc-studio-execution-java/pull/29
- https://github.com/eclipse/gemoc-studio-execution-ale/pull/57
- https://github.com/eclipse/gemoc-studio-execution-moccml/pull/73
- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/226
 when https://github.com/diverse-project/k3/pull/87 will be deployed

