### PR TITLE
Manage step params in MW test cases

### DIFF
--- a/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DebugOfficialExampleK3FSM_Test.xtend
+++ b/gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb/src/org/eclipse/gemoc/studio/tests/system/mwb/userstory/DebugOfficialExampleK3FSM_Test.xtend
@@ -280,7 +280,7 @@ class DebugOfficialExampleK3FSM_Test extends AbstractXtextTests
 		bot.tree().getTreeItem("K3FSM- TwoStates(abababa) [Executable model with GEMOC Java engine]").waitNode("Gemoc debug target").waitNode("Model debugging").select();
 		bot.tree().getTreeItem("K3FSM- TwoStates(abababa) [Executable model with GEMOC Java engine]").getNode("Gemoc debug target").getNode("Model debugging").expand();
 		bot.tree().getTreeItem("K3FSM- TwoStates(abababa) [Executable model with GEMOC Java engine]").getNode("Gemoc debug target").getNode("Model debugging").waitNode("Engine : TwoStates.k3fsm => TwoStates").select();
-		bot.tree().getTreeItem("K3FSM- TwoStates(abababa) [Executable model with GEMOC Java engine]").getNode("Gemoc debug target").getNode("Model debugging").waitNode("[FSM] TwoStates#initializeModel([])").select();
+		bot.tree().getTreeItem("K3FSM- TwoStates(abababa) [Executable model with GEMOC Java engine]").getNode("Gemoc debug target").getNode("Model debugging").waitNode("[FSM] TwoStates#initializeModel([abababa])").select();
 		
 		
 		closeConfigureXtextPopup(bot)


### PR DESCRIPTION
## Description

In MW UI test cases, we explicitly check for a string with the complete signature of an execution trace in the stack trace.

(This is indirectly the reason for this failing test result: https://ci.eclipse.org/gemoc/job/gemoc-studio-integration/job/stepReturn/10/testReport/)

Until now, such parameters were not correctly provided to step objects, and thus not displayed. This changes with this other PR: https://github.com/eclipse/gemoc-studio-modeldebugging/pull/227

The current PR adapts the MW test case to expect the step parameter to be displayed, as we should have expected in the first place.

## Companion Pull Requests

(Warning: I forgot to give the same name to both branches)

 - PR https://github.com/eclipse/gemoc-studio-modeldebugging/pull/227
