### PR TITLE
Bump K3 version to 2022-12-20

### DIFF
--- a/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
+++ b/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
@@ -39,7 +39,7 @@
     	<eclipse.release.p2.url>http://download.eclipse.org/releases/2022-06</eclipse.release.p2.url>
         <!--used only for amalgam which seems REALLY deprecated-->
         <eclipse.photon.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.photon.release.p2.url>
-		<k3.p2.url>http://www.kermeta.org/k3/update_2022-09-08</k3.p2.url>
+		<k3.p2.url>http://www.kermeta.org/k3/update_2022-12-20</k3.p2.url>
 		<ale.p2.url>http://www.kermeta.org/ale-lang/updates/2020-07-17</ale.p2.url>
 		<!-- <ale.p2.url>https://ci.inria.fr/gemoc/job/ale-lang/job/bump-to-eclipse-2020-03/lastSuccessfulBuild/artifact/releng/org.eclipse.emf.ecoretools.ale.updatesite/target/repository/</ale.p2.url>-->
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2022-09-29</melange.p2.url>


### PR DESCRIPTION
Required to fix the `master` branch (see https://ci.eclipse.org/gemoc/job/gemoc-studio-integration/job/master/448/)