### PR TITLE
Bump xtend and k3

### DIFF
--- a/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
+++ b/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
@@ -34,12 +34,12 @@
 		<maven.deploy.skip>true</maven.deploy.skip>
 		
 		<tycho-version>2.7.3</tycho-version>
-    	<xtend.version>2.25.0</xtend.version>
+    	<xtend.version>2.27.0</xtend.version>
     	
     	<eclipse.release.p2.url>http://download.eclipse.org/releases/2022-06</eclipse.release.p2.url>
         <!--used only for amalgam which seems REALLY deprecated-->
         <eclipse.photon.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.photon.release.p2.url>
-		<k3.p2.url>http://www.kermeta.org/k3/update_2022-12-20</k3.p2.url>
+		<k3.p2.url>http://www.kermeta.org/k3/update_2023-01-09</k3.p2.url>
 		<ale.p2.url>http://www.kermeta.org/ale-lang/updates/2020-07-17</ale.p2.url>
 		<!-- <ale.p2.url>https://ci.inria.fr/gemoc/job/ale-lang/job/bump-to-eclipse-2020-03/lastSuccessfulBuild/artifact/releng/org.eclipse.emf.ecoretools.ale.updatesite/target/repository/</ale.p2.url>-->
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2022-09-29</melange.p2.url>


### PR DESCRIPTION
align xtend to 2.27.0 available in eclipse 2022-06 
use latest version of k3 (2023-01-09)
