### PR TITLE
Bump to version of k3 including StepCommand return null fix

### DIFF
--- a/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
+++ b/gemoc_studio/plugins/gemoc_studio-eclipse-bom/pom.xml
@@ -39,7 +39,7 @@
     	<eclipse.release.p2.url>http://download.eclipse.org/releases/2022-06</eclipse.release.p2.url>
         <!--used only for amalgam which seems REALLY deprecated-->
         <eclipse.photon.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.photon.release.p2.url>
-		<k3.p2.url>http://www.kermeta.org/k3/update_2023-02-24</k3.p2.url>
+		<k3.p2.url>http://www.kermeta.org/k3/update_2023-04-03</k3.p2.url>
 		<ale.p2.url>http://www.kermeta.org/ale-lang/updates/2020-07-17</ale.p2.url>
 		<!-- <ale.p2.url>https://ci.inria.fr/gemoc/job/ale-lang/job/bump-to-eclipse-2020-03/lastSuccessfulBuild/artifact/releng/org.eclipse.emf.ecoretools.ale.updatesite/target/repository/</ale.p2.url>-->
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2022-09-29</melange.p2.url>


### PR DESCRIPTION
## Description

Bump to the latest version of K3 that includes the support for all kind of StepCommand (ie. result being  void, null or an object)

## Companion Pull Requests


 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/229
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/59
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/30
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/74
