### PR TITLE
fix download page of nightly build

### DIFF
--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/src/main/filtered-resources/products/index.html
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/src/main/filtered-resources/products/index.html
@@ -199,13 +199,13 @@
           <p>The headless version is a limited version that offers only command line interface.</p>
           <p><b>Build date: ${timestamp}</b></p>
           <div id='dirlist' style='display:inline;'><img src='https://dev.eclipse.org/small_icons/places/folder.png'><a href='/gemoc/packages/nightly/../?d'> ..</a><br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-linux.gtk.x86_64.zip'> gemoc_studio-linux.gtk.x86_64.zip</a><br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-macosx.cocoa.x86_64.zip'> gemoc_studio-macosx.cocoa.x86_64.zip</a> <br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-macosx.cocoa.aarch64.zip'> gemoc_studio-macosx.cocoa.aarch64.zip</a> <br />
+<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-linux.gtk.x86_64.tar.gz'> gemoc_studio-linux.gtk.x86_64.tar.gz</a><br />
+<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-macosx.cocoa.x86_64.tar.gz'> gemoc_studio-macosx.cocoa.x86_64.tar.gz</a> <br />
+<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-macosx.cocoa.aarch64.tar.gz'> gemoc_studio-macosx.cocoa.aarch64.tar.gz</a> <br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio-win32.win32.x86_64.zip'> gemoc_studio-win32.win32.x86_64.zip</a><br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-linux.gtk.x86_64.zip'> gemoc_studio_headless_engine_runner-linux.gtk.x86_64.zip</a><br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-macosx.cocoa.x86_64.zip'> gemoc_studio_headless_engine_runner-macosx.cocoa.x86_64.zip</a> <br />
-<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-macosx.cocoa.aarch64.zip'> gemoc_studio_headless_engine_runner-macosx.cocoa.aarch64.zip</a> <br />
+<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-linux.gtk.x86_64.zip'> gemoc_studio_headless_engine_runner-linux.gtk.x86_64.tar.gz</a><br />
+<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-macosx.cocoa.x86_64.tar.gz'> gemoc_studio_headless_engine_runner-macosx.cocoa.x86_64.tar.gz</a> <br />
+<img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-macosx.cocoa.aarch64.tar.gz'> gemoc_studio_headless_engine_runner-macosx.cocoa.aarch64.tar.gz</a> <br />
 <img src='https://dev.eclipse.org/small_icons/actions/edit-copy.png'><a href='/gemoc/packages/nightly/gemoc_studio_headless_engine_runner-win32.win32.x86_64.zip'> gemoc_studio_headless_engine_runner-win32.win32.x86_64.zip</a><br />
 </div><script language='javascript' src='/errors/js.js'></script>
           <h2>Other useful links</h2>


### PR DESCRIPTION
## Description

Fixes the download page for the current nightly build


With the new Eclipse version 2023-06 (see    #299  ) Linux and macos versions are distributed as tag.gz instead of zip 

This PR adapts the download page index https://download.eclipse.org/gemoc/packages/nightly/ to correctly point to these artefacts.