### PR TITLE
Adapt product configuration to be more similar to classic eclipse packages

### DIFF
--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.additions.feature/feature.xml
@@ -57,32 +57,29 @@ http://www.eclipse.org/legal/epl-v10.html
          version="0.0.0"/>
 
    <requires>
-      <import feature="org.eclipse.egit" version="0.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.jgit" version="0.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.platform" version="4.7.3" match="greaterOrEqual"/>
-      <import feature="org.eclipse.platform.source" version="4.7.3" match="greaterOrEqual"/>
-      <import feature="org.eclipse.jdt" version="3.13.3" match="greaterOrEqual"/>
-      <import feature="org.eclipse.jdt.source" version="3.13.3" match="greaterOrEqual"/>
-      <import feature="org.eclipse.pde" version="2.2.103" match="greaterOrEqual"/>
-      <import feature="org.eclipse.pde.source" version="2.2.103" match="greaterOrEqual"/>
-      <import feature="org.eclipse.help" version="2.2.103" match="greaterOrEqual"/>
-      <import feature="org.eclipse.emf.common.source" version="2.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.emf.ecore.source" version="2.7.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.ecf.core.feature.source" version="1.4.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.ecf.core.ssl.feature.source" version="1.1.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.ecf.filetransfer.feature.source" version="3.13.7" match="greaterOrEqual"/>
-      <import feature="org.eclipse.ecf.filetransfer.ssl.feature.source" version="1.1.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.emf.ecoretools.registration.feature" version="3.3.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.jdt" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.jdt.source" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.pde" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.pde.source" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.pde.spies" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.help" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.common.source" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.ecore.source" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.ecf.core.feature.source" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.ecf.core.ssl.feature.source" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.ecf.filetransfer.feature.source" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.ecf.filetransfer.ssl.feature.source" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.ecoretools.registration.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.query.sdk" version="0.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.emf.compare" version="2.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.emf.compare.ide.ui" version="2.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.compare" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.compare.ide.ui" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.diffmerge.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.diffmerge.gmf.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.diffmerge.sirius.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.diffmerge.egit.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.m2e.feature" version="0.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.m2e.logback.feature" version="0.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.epp.mpc" version="1.2.1.v20140219-1000" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.pde.feature" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.lemminx.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.xtend.sdk" version="0.0.0"/>
       <import feature="org.eclipse.m2m.qvt.oml" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.m2m.qvt.oml.debug" version="0.0.0" match="greaterOrEqual"/>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.branding.feature/feature.xml
@@ -34,14 +34,15 @@ http://www.eclipse.org/legal/epl-v10.html
    </license>
 
    <requires>
-      <import feature="org.eclipse.xtext.sdk" version="2.5.4" match="greaterOrEqual"/>
-      <import feature="org.eclipse.xtend.sdk" version="2.5.4" match="greaterOrEqual"/>
+      <import feature="org.eclipse.xtext.sdk" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.xtend.sdk" version="0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.lsp4j.sdk" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.ocl.examples" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.ecoretools.design" version="2.0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.gemoc.modeldebugging.feature" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.gemoc.modeldebugging.feature.source" version="0.0.0" match="greaterOrEqual"/>
       <import feature="fr.inria.diverse.k3.feature" version="0.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.sirius.specifier" version="5.0.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.sirius.specifier" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.e4.rcp" version="0.0.0" match="greaterOrEqual"/>
       <import feature="fr.inria.diverse.melange.sdk" version="0.0.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.emf.ecoretools.ale.feature" version="0.0.0" match="greaterOrEqual"/>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="GEMOCStudio Target platform" sequenceNumber="1699547113">
+<target name="GEMOCStudio Target platform" sequenceNumber="1700842450">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.acceleo.feature.group" version="3.7.13.202304041222"/>
@@ -10,6 +10,7 @@
       <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.1.701.v20230423-0417"/>
       <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.401.v20230422-0242"/>
       <unit id="org.eclipse.egit.feature.group" version="6.6.0.202305301015-r"/>
+      <unit id="org.eclipse.egit.gitflow.feature.feature.group" version="6.6.0.202305301015-r"/>
       <unit id="org.eclipse.emf.feature.group" version="2.34.0.v20230406-1334"/>
       <unit id="org.eclipse.emf.compare.feature.group" version="3.3.21.202212280858"/>
       <unit id="org.eclipse.emf.compare.rcp" version="2.5.2.202212280858"/>
@@ -20,6 +21,7 @@
       <unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="2.14.0.v20221117-1134"/>
       <unit id="org.eclipse.emf.query.sdk.feature.group" version="1.12.1.202208101410"/>
       <unit id="org.eclipse.epp.mpc.feature.group" version="1.10.1.v20221110-1841"/>
+      <unit id="org.eclipse.epp.package.common.feature.feature.group" version="4.28.0.20230608-1200"/>
       <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.11.2000.v20230510-1208"/>
       <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.2100.v20230415-0944"/>
       <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.11.100.v20221109-0702"/>
@@ -31,12 +33,15 @@
       <unit id="org.eclipse.m2m.qvt.oml.editor.feature.group" version="3.10.7.v20220605-1149"/>
       <unit id="org.eclipse.m2m.qvt.oml.runtime.feature.group" version="3.10.7.v20220605-1149"/>
       <unit id="org.eclipse.m2m.qvt.oml.sdk.feature.group" version="3.10.7.v20220605-1149"/>
+      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="3.0.46.202301111837"/>
       <unit id="org.eclipse.ocl.examples.feature.group" version="6.18.0.v20221201-0557"/>
+      <unit id="org.eclipse.oomph.setup.feature.group" version="1.28.0.v20230523-0636"/>
       <unit id="org.eclipse.rcp.feature.group" version="4.28.0.v20230605-0440"/>
       <unit id="org.eclipse.sdk.feature.group" version="4.28.0.v20230605-0440"/>
       <unit id="org.eclipse.swtbot.eclipse.feature.group" version="4.1.0.202306071420"/>
       <unit id="org.eclipse.swtbot.ide.feature.group" version="4.1.0.202306071420"/>
       <unit id="org.eclipse.swtbot.feature.group" version="4.1.0.202306071420"/>
+      <unit id="org.eclipse.tm.terminal.feature.feature.group" version="11.2.0.202303131754"/>
       <unit id="org.eclipse.wst.web_core.feature.feature.group" version="3.30.0.v202305230750"/>
       <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.30.0.v202305230750"/>
       <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.30.0.v202305230750"/>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.tpd
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.tpd
@@ -20,6 +20,7 @@ location eclipse "https://download.eclipse.org/releases/2023-06" {
 	org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group
 	org.eclipse.ecf.filetransfer.ssl.feature.feature.group
 	org.eclipse.egit.feature.group
+	org.eclipse.egit.gitflow.feature.feature.group
 	org.eclipse.emf.feature.group
 	org.eclipse.emf.compare.feature.group
 	org.eclipse.emf.compare.rcp
@@ -30,6 +31,7 @@ location eclipse "https://download.eclipse.org/releases/2023-06" {
 	org.eclipse.emf.mwe2.language.sdk.feature.group
 	org.eclipse.emf.query.sdk.feature.group
 	org.eclipse.epp.mpc.feature.group
+	org.eclipse.epp.package.common.feature.feature.group
 	org.eclipse.equinox.p2.sdk.feature.group
 	org.eclipse.equinox.executable.feature.group
 	org.eclipse.equinox.server.jetty.feature.group
@@ -41,13 +43,16 @@ location eclipse "https://download.eclipse.org/releases/2023-06" {
 	org.eclipse.m2m.qvt.oml.editor.feature.group
 	org.eclipse.m2m.qvt.oml.runtime.feature.group
 	org.eclipse.m2m.qvt.oml.sdk.feature.group
+	org.eclipse.mylyn.wikitext_feature.feature.group
 	org.eclipse.ocl.examples.feature.group
+	org.eclipse.oomph.setup.feature.group
 	//org.eclipse.cdt.feature.group
 	org.eclipse.rcp.feature.group
 	org.eclipse.sdk.feature.group
 	org.eclipse.swtbot.eclipse.feature.group
 	org.eclipse.swtbot.ide.feature.group
 	org.eclipse.swtbot.feature.group
+	org.eclipse.tm.terminal.feature.feature.group
 	org.eclipse.wst.web_core.feature.feature.group
 	org.eclipse.wst.xml_core.feature.feature.group
 	org.eclipse.wst.xml_ui.feature.feature.group
@@ -64,6 +69,7 @@ location eclipse "https://download.eclipse.org/releases/2023-06" {
 	org.eclipse.xtext.generator
 	javax.annotation
 }
+
 
 location sirius "https://download.eclipse.org/sirius/updates/releases/7.2.0/2023-03/" {
 	org.eclipse.sirius.specifier.feature.group

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.updatesite/gemoc_studio.product
@@ -14,21 +14,27 @@
    </configIni>
 
    <launcherArgs>
-      <programArgs>-product
-org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio
---launcher.defaultAction
-openFile
+      <programArgs>-product org.eclipse.gemoc.gemoc_studio.branding.gemoc_studio
+--launcher.defaultAction openFile
+--launcher.appendVmargs
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=11
+      <vmArgs>-Dosgi.requiredJavaVersion=17
 -Dosgi.instance.area.default=@user.home/eclipse-workspaces/gemoc-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
+-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dosgi.framework.extensions=org.eclipse.fx.osgi
+-Declipse.e4.inject.javax.warning=false
+-Dsun.java.command=GemocStudio
 -XX:+UseG1GC
 -XX:+UseStringDeduplication
--Dosgi.framework.extensions=org.eclipse.fx.osgi
 -Xms256m
 -Xmx2048m
+--add-modules=ALL-SYSTEM
+-Djava.security.manager=allow
       </vmArgs>
-      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      <vmArgsMac>-XstartOnFirstThread 
+-Dorg.eclipse.swt.internal.carbon.smallFonts
+-Xdock:icon=../Resources/GemocStudio.icns
       </vmArgsMac>
    </launcherArgs>
 
@@ -36,7 +42,9 @@ openFile
 
    <splash
       location="org.eclipse.gemoc.gemoc_studio.branding"
-      startupProgressRect="5,275,445,15" />
+      startupProgressRect="5,275,445,15"
+      startupMessageRect="7,252,320,20"
+      startupForegroundColor="ffffff" />
    <launcher name="GemocStudio">
       <linux icon="/images/icons/IconeGemocStudio-text/xpm/IconeGemocStudio-text.xpm"/>
       <macosx icon="/images/icons/IconeGemocStudio-text/icns/IconeGemocStudio-text.icns"/>
@@ -52,19 +60,189 @@ openFile
       </win>
    </launcher>
 
+
    <vm>
       <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</linux>
       <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</macos>
       <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
    </vm>
 
+   <license>
+        <url>http://eclipse.org/legal/epl/notice.php</url>
+        <text>
+   Eclipse Foundation Software User Agreement
+
+November 22, 2017
+
+Usage Of Content
+
+THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION
+AND/OR OTHER MATERIALS FOR OPEN SOURCE PROJECTS (COLLECTIVELY &amp;quot;CONTENT&amp;quot;). USE OF
+THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS AGREEMENT AND/OR THE
+TERMS AND CONDITIONS OF LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED
+BELOW. BY USING THE CONTENT, YOU AGREE THAT YOUR USE OF THE CONTENT IS GOVERNED
+BY THIS AGREEMENT AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE
+AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW. IF YOU DO NOT AGREE TO THE
+TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND CONDITIONS OF ANY
+APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW, THEN YOU
+MAY NOT USE THE CONTENT.
+
+Applicable Licenses
+
+Unless otherwise indicated, all Content made available by the Eclipse Foundation
+is provided to you under the terms and conditions of the Eclipse Public License
+Version 2.0 (&amp;quot;EPL&amp;quot;). A copy of the EPL is provided with this Content and is also
+available at http://www.eclipse.org/legal/epl-2.0. For purposes of the EPL,
+&amp;quot;Program&amp;quot; will mean the Content.
+
+Content includes, but is not limited to, source code, object code, documentation
+and other files maintained in the Eclipse Foundation source code repository
+(&amp;quot;Repository&amp;quot;) in software modules (&amp;quot;Modules&amp;quot;) and made available as
+downloadable archives (&amp;quot;Downloads&amp;quot;).
+
+-   Content may be structured and packaged into modules to facilitate
+    delivering, extending, and upgrading the Content. Typical modules may
+    include plug-ins (&amp;quot;Plug-ins&amp;quot;), plug-in fragments (&amp;quot;Fragments&amp;quot;), and
+    features (&amp;quot;Features&amp;quot;).
+-   Each Plug-in or Fragment may be packaged as a sub-directory or JAR
+    (Java™ ARchive) in a directory named &amp;quot;plugins&amp;quot;.
+-   A Feature is a bundle of one or more Plug-ins and/or Fragments and
+    associated material. Each Feature may be packaged as a sub-directory in a
+    directory named &amp;quot;features&amp;quot;. Within a Feature, files named &amp;quot;feature.xml&amp;quot; may
+    contain a list of the names and version numbers of the Plug-ins and/or
+    Fragments associated with that Feature.
+-   Features may also include other Features (&amp;quot;Included Features&amp;quot;). Within a
+    Feature, files named &amp;quot;feature.xml&amp;quot; may contain a list of the names and
+    version numbers of Included Features.
+
+The terms and conditions governing Plug-ins and Fragments should be contained in
+files named &amp;quot;about.html&amp;quot; (&amp;quot;Abouts&amp;quot;). The terms and conditions governing Features
+and Included Features should be contained in files named &amp;quot;license.html&amp;quot;
+(&amp;quot;Feature Licenses&amp;quot;). Abouts and Feature Licenses may be located in any
+directory of a Download or Module including, but not limited to the following
+locations:
+
+-   The top-level (root) directory
+-   Plug-in and Fragment directories
+-   Inside Plug-ins and Fragments packaged as JARs
+-   Sub-directories of the directory named &amp;quot;src&amp;quot; of certain Plug-ins
+-   Feature directories
+
+Note: if a Feature made available by the Eclipse Foundation is installed using
+the Provisioning Technology (as defined below), you must agree to a license
+(&amp;quot;Feature Update License&amp;quot;) during the installation process. If the Feature
+contains Included Features, the Feature Update License should either provide you
+with the terms and conditions governing the Included Features or inform you
+where you can locate them. Feature Update Licenses may be found in the &amp;quot;license&amp;quot;
+property of files named &amp;quot;feature.properties&amp;quot; found within a Feature. Such
+Abouts, Feature Licenses, and Feature Update Licenses contain the terms and
+conditions (or references to such terms and conditions) that govern your use of
+the associated Content in that directory.
+
+THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL
+OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE
+OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):
+
+-   Eclipse Public License Version 1.0 (available at
+    http://www.eclipse.org/legal/epl-v10.html)
+-   Eclipse Distribution License Version 1.0 (available at
+    http://www.eclipse.org/licenses/edl-v1.0.html)
+-   Common Public License Version 1.0 (available at
+    http://www.eclipse.org/legal/cpl-v10.html)
+-   Apache Software License 1.1 (available at
+    http://www.apache.org/licenses/LICENSE)
+-   Apache Software License 2.0 (available at
+    http://www.apache.org/licenses/LICENSE-2.0)
+-   Mozilla Public License Version 1.1 (available at
+    http://www.mozilla.org/MPL/MPL-1.1.html)
+
+IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR TO
+USE OF THE CONTENT. If no About, Feature License, or Feature Update License is
+provided, please contact the Eclipse Foundation to determine what terms and
+conditions govern that particular Content.
+
+Use of Provisioning Technology
+
+The Eclipse Foundation makes available provisioning software, examples of which
+include, but are not limited to, p2 and the Eclipse Update Manager
+(&amp;quot;Provisioning Technology&amp;quot;) for the purpose of allowing users to install
+software, documentation, information and/or other materials (collectively
+&amp;quot;Installable Software&amp;quot;). This capability is provided with the intent of allowing
+such users to install, extend and update Eclipse-based products. Information
+about packaging Installable Software is available at
+http://eclipse.org/equinox/p2/repository_packaging.html (&amp;quot;Specification&amp;quot;).
+
+You may use Provisioning Technology to allow other parties to install
+Installable Software. You shall be responsible for enabling the applicable
+license agreements relating to the Installable Software to be presented to, and
+accepted by, the users of the Provisioning Technology in accordance with the
+Specification. By using Provisioning Technology in such a manner and making it
+available in accordance with the Specification, you further acknowledge your
+agreement to, and the acquisition of all necessary rights to permit the
+following:
+
+1.  A series of actions may occur (&amp;quot;Provisioning Process&amp;quot;) in which a user may
+    execute the Provisioning Technology on a machine (&amp;quot;Target Machine&amp;quot;) with the
+    intent of installing, extending or updating the functionality of an
+    Eclipse-based product.
+2.  During the Provisioning Process, the Provisioning Technology may cause third
+    party Installable Software or a portion thereof to be accessed and copied to
+    the Target Machine.
+3.  Pursuant to the Specification, you will provide to the user the terms and
+    conditions that govern the use of the Installable Software (&amp;quot;Installable
+    Software Agreement&amp;quot;) and such Installable Software Agreement shall be
+    accessed from the Target Machine in accordance with the Specification. Such
+    Installable Software Agreement must inform the user of the terms and
+    conditions that govern the Installable Software and must solicit acceptance
+    by the end user in the manner prescribed in such Installable
+    Software Agreement. Upon such indication of agreement by the user, the
+    provisioning Technology will complete installation of the
+    Installable Software.
+
+Cryptography
+
+Content may contain encryption software. The country in which you are currently
+may have restrictions on the import, possession, and use, and/or re-export to
+another country, of encryption software. BEFORE using any encryption software,
+please check the country&amp;apos;s laws, regulations and policies concerning the import,
+possession, or use, and re-export of encryption software, to see if this is
+permitted.
+
+Java and all Java-based trademarks are trademarks of Oracle Corporation in the
+United States, other countries, or both.
+         </text>
+   </license>
+
    <plugins>
    </plugins>
 
    <features>
+      <!-- all features added here as installMode="root" need to be added to p2.inf as well -->
+
+      <!-- common features that all products have -->
+      <feature id="org.eclipse.epp.package.common.feature"/>
+      <feature id="org.eclipse.platform"/>
+      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.epp.mpc" installMode="root"/>
+      <feature id="org.eclipse.oomph.setup" installMode="root"/>
+      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.egit" installMode="root"/>
+      <feature id="org.eclipse.jgit" installMode="root"/>
+      <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+            
+      <!-- common features to almost all products -->
+      
+      <!-- product specific contents -->
       <feature id="org.eclipse.gemoc.gemoc_studio.branding.feature"/>
       <feature id="org.eclipse.gemoc.gemoc_studio.additions.feature"/>
       <feature id="org.eclipse.fx.runtime.min.feature" installMode="root"/>
+      
+      
+      <feature id="org.eclipse.egit.gitflow.feature" installMode="root"/>
+      <!-- either m2e.logback or slf4j.simple should be provided in each package -->
+      <feature id="org.eclipse.m2e.logback.feature" installMode="root"/>
+      
+      
    </features>
 
    <configurations>


### PR DESCRIPTION




## Description


This PR adapt the product configuration and feature to be more similar to the classic eclipse product (cf. https://github.com/eclipse-packaging/packages/tree/master/packages)


It ensures that `launcherArgs` are the same as the official ones. 
- this should help resolve MacOS icon issue.

It adds several new features that are usually part of the classic eclipse packages
- terminal (`org.eclipse.tm.terminal`)
- wikitext (`org.eclipse.mylyn.wikitext`)
- oomph (`org.eclipse.oomph.setup`) (contributes to https://github.com/eclipse/gemoc-studio/issues/234)
- gitflow (`org.eclipse.egit.gitflow`
- lsp4j (`org.eclipse.lsp4j.sdk`)
- pde support (`org.eclipse.pde.spies`)
- maven editor (`org.eclipse.m2e.lemminx`)


 
