### PR TITLE
Adapt docker for local build

### DIFF
--- a/.project
+++ b/.project
@@ -5,7 +5,24 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1722281445779</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/dev_support/gemoc_builder/README.asciidoc
+++ b/dev_support/gemoc_builder/README.asciidoc
@@ -16,7 +16,7 @@ To do a full build using docker: go to the docker folder (*/gemoc-studio/dev_sup
 
 [source,bourne]
 ----
-docker build -t "gemoc/gemoc_builder:latest" .
+docker build -t "gemoc/gemoc-builder:latest" .
 ---- 
 
 
@@ -26,7 +26,7 @@ docker build -t "gemoc/gemoc_builder:latest" .
 ===== Interactive usage
 
 ```
-docker run -it --rm --name gemoc_builder -v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc_builder:latest" /bin/bash
+docker run -it --rm --name gemoc-builder -v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" /bin/bash
 ```
 
 

--- a/dev_support/gemoc_builder/README.asciidoc
+++ b/dev_support/gemoc_builder/README.asciidoc
@@ -1,0 +1,79 @@
+=== Docker support for compiling the GEMOC studio locally (including UI tests)
+
+in many case, it is useful to have a docker image to help compile the studio
+
+either because one doesn't want to install all the tools, or because the UI tests are quite long to run and normal opertion on the PC may interfere. 
+it may also be used by the CI 
+
+
+This Docker image intend to provide some support to launch all the compilation tasks in isolation while allowing to connect (via VNC) to the UI if required.
+
+ 
+
+==== build image
+
+To do a full build using docker: go to the docker folder (*/gemoc-studio/dev_support/full_compilation/docker*), then call the command
+
+[source,bourne]
+----
+docker build -t "gemoc/gemoc_builder:latest" .
+---- 
+
+
+==== Use of the image
+
+
+===== Interactive usage
+
+```
+docker run -it --rm --name gemoc_builder -v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc_builder:latest" /bin/bash
+```
+
+
+Optionnaly, open the GUI (useful for graphical integration tests)
+
+```
+vncviewer localhost:5901
+```
+
+Where:
+
+- `$PWD/../../../..` points to the root containing all gemoc sources (this suppose that you run the script from the folder containing the `Dockerfile` file)
+- `--env UID=$(id -u) --env GID=$(id -g)`  makes sure to use your user uid (use `id -u` or `echo $UID`to get yours user uid if this isn't 1000)
+- `-p 5901:5901` is the port used to connected to the UI using VNC  
+
+WARNING: you must create the _$PWD/cache-m2_ folder before launching the docker command in order to avoid permission issues.
+
+The image contains several build scripts for various common usages.
+
+- `generate_protocols.sh` with the possible arguments
+** `full` -> npm install; npm run build; npm run generate
+
+- `tycho_build.sh` with the possible arguments
+** `full` -> mvn clean install
+** `clean` -> mvn clean
+** `linux` compile gemoc studio for linux only, online, install in .m2
+** `linux_no_system_test` compile gemoc studio for linux only no system tests, online, install in .m2
+** `linux_no_system_test_offline` compile gemoc studio for linux only no system tests, offline, install in .m2
+** `linux_offline` compile gemoc studio for linux only, offline, install in .m2
+** `linux_system_test_only` running system tests only
+** `tycho_dependencies` display the plugin dependencies computed by tycho
+
+- `pomfirst_build.sh` with the possible arguments
+** `full` -> mvn clean install
+** `clean` -> mvn clean
+   
+TIP: you can timestamp the console and save in a local log by adding `|& ts -s |& tee build.log` at the end of the command (where `ts` comes from the the `moreutils` package)
+
+
+
+===== Description of the docker env
+
+The _Dockerfile_ defines a docker image based on ubuntu 24.04 with maven, oracle java17, xvfb, and graphviz. It embeds an *entrypoint.sh* script that allows to run using your own userId. (To avoid issue about file created as root instead of your local uid, it uses `gosu`  in the entrypoint script (cf. https://stackoverflow.com/questions/57776452/is-it-possible-to-map-a-user-inside-the-docker-container-to-an-outside-user))
+
+The _docker-compose.yml_ will mount the folder containing all gemoc repositories (ie. the place where you've done `git clone`) 
+
+It also mounts a *cache-m2* folder in order to speed up successive compilations.
+
+
+

--- a/dev_support/gemoc_builder/README.asciidoc
+++ b/dev_support/gemoc_builder/README.asciidoc
@@ -19,6 +19,13 @@ To do a full build using docker: go to the docker folder (*/gemoc-studio/dev_sup
 docker build -t "gemoc/gemoc-builder:latest" .
 ---- 
 
+or with a fixed date
+
+[source,bourne]
+----
+docker build -t "gemoc/gemoc-builder:2024-08-02" .
+---- 
+
 
 ==== Use of the image
 
@@ -65,7 +72,10 @@ The image contains several build scripts for various common usages.
    
 TIP: you can timestamp the console and save in a local log by adding `|& ts -s |& tee build.log` at the end of the command (where `ts` comes from the the `moreutils` package)
 
-
+typicall use: (for the folder containing all the git repositories
+```
+docker run -it --rm --name gemoc-builder -v $PWD:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" ./tycho_build.sh linux |& ts -s |& tee linux_build.log
+```
 
 ===== Description of the docker env
 

--- a/dev_support/gemoc_builder/docker/Dockerfile
+++ b/dev_support/gemoc_builder/docker/Dockerfile
@@ -1,0 +1,199 @@
+###############################################################
+# Image content overview:
+# - ubuntu 
+# - graphviz
+# - openjdk8, openfx, maven 3.6.0
+# - Xvfb
+# - helper build script for gemoc
+# user id support (for correct ownership of produced files)
+# the docker file is greatly inspired from images at https://github.com/eclipse-cbi/dockerfiles
+###############################################################
+# Rationale:
+# main goal : be able to be usable both in jenkins (on jenkins.eclipse.org new infrastructure) and locally by developpers
+# version selection: 
+# - due to bug in recent version of graphviz we must stick to an older version (cf. https://forum.plantuml.net/5425/relation-long-with-graphviz-using-labels-relations-namespace)
+#   the quickest workaround was to use an older version of ubuntu that has graphviz 2.39.x
+# - use of Xvfb instead of vnc (unlike images from  https://github.com/eclipse-cbi/dockerfiles)
+#		this is because ubuntu 16 use tighvnc instead of tigervnc and tighvnc doesn't support the passwordFile option)
+# - openjdk8 + openjfx : due to recent change in oracle java distribution license
+###############################################################
+
+
+FROM ubuntu:24.04
+
+ARG MAVEN_VERSION=3.9.8
+ARG MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
+
+# nvm environment variables
+#ENV NVM_DIR=/usr/local/nvm
+#ENV NODE_VERSION=20.15.1
+
+ARG DOCKER_USER=ubuntu
+
+# ubuntu user already exists in base image
+#RUN groupadd  $DOCKER_USER
+#RUN useradd  -ms /bin/bash -d /home/$DOCKER_USER -g $DOCKER_USER $DOCKER_USER
+
+#RUN addgroup "$DOCKER_USER" \
+# 	&& adduser "$DOCKER_USER" -G "$DOCKER_USER"
+ 
+RUN apt update && apt upgrade -y && apt install -y  --no-install-recommends \
+	gosu
+
+COPY scripts/entrypoint /entrypoint
+RUN chmod 0755 /entrypoint \
+	&& sed "s/\$DOCKER_USER/$DOCKER_USER/g" -i /entrypoint
+#RUN chmod u+x /usr/local/bin/uid_entrypoint && \
+#    chgrp 0 /usr/local/bin/uid_entrypoint && \
+#    chmod g=u /usr/local/bin/uid_entrypoint /etc/passwd
+ENTRYPOINT [ "/entrypoint" ]
+
+#ENV DEBIAN_FRONTEND noninteractive
+
+# 	libgtk-3-0=3.18.* 
+
+RUN apt update && apt upgrade -y && apt install -y  --no-install-recommends\
+	language-pack-en-base \
+	x11-xserver-utils \
+	libgl1-mesa-dri \
+	xfonts-base \
+	xfonts-scalable \
+	xfonts-100dpi \
+	xfonts-75dpi \
+	fonts-liberation \
+	fonts-freefont-ttf \
+	fonts-dejavu \
+	fonts-dejavu-core \
+	fonts-dejavu-extra \
+	moreutils \
+	zip \
+	unzip \
+	curl \
+	wget \
+	graphviz
+
+# Java
+
+RUN apt-get install -y  --no-install-recommends \
+	openjdk-17-jdk \
+	openjfx 
+
+RUN wget https://download2.gluonhq.com/openjfx/17.0.2/openjfx-17.0.2_linux-x64_bin-sdk.zip  -O ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip 
+RUN unzip ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip -d /usr/share/
+RUN rm ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip 
+
+ENV JAVAFX_HOME=/usr/share/javafx-sdk-17.0.2
+	
+# install maven 
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+ && curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+ && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+ && rm -f /tmp/apache-maven.tar.gz \
+ && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ENV MAVEN_HOME=/usr/share/maven
+
+
+
+# Headless UI Management
+
+RUN apt-get install -y  --no-install-recommends \
+	sddm \	
+	openbox \
+	dbus \
+	dbus-x11
+	 
+# added in an attempt to capture a video of the x display while running UI tests
+# cf. https://malinowski.dev/recording-headless-selenium-tests-to-mp4.html
+RUN apt update && apt upgrade -y && apt install -y  --no-install-recommends\
+	ffmpeg \
+	tmux
+
+ENV HOME=/home/$DOCKER_USER
+
+
+# install NodeJs via nvm
+USER $DOCKER_USER
+ENV NODE_VERSION=20.16.0
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash 
+ENV NVM_DIR=$HOME/.nvm
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="${HOME}/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version
+RUN npm --version  
+USER root
+
+# avoid "library appears to be incorrectly set up; failed to read machine uuid: UUID file '/etc/machine-id' should contain a hex string of length 32" when launching x 
+# cf http://www.torkwrench.com/2011/12/16/d-bus-library-appears-to-be-incorrectly-set-up-failed-to-read-machine-uuid-failed-to-open-varlibdbusmachine-id/ and https://github.com/activatedgeek/docker-videostack/issues/1
+RUN dbus-uuidgen > /var/lib/dbus/machine-id
+RUN mkdir -p ${HOME}/.cache && \
+	chmod 1777 ${HOME}/.cache \
+    && chown -R $DOCKER_USER:$DOCKER_USER ${HOME}/.cache
+
+# avoid _XSERVTransmkdir: ERROR: euid != 0,directory /tmp/.X11-unix will not be created.
+RUN mkdir /tmp/.X11-unix && \
+	chmod 1777 /tmp/.X11-unix && \
+	chown $DOCKER_USER /tmp/.X11-unix/
+
+
+# Create an .Xauthority file
+RUN touch ${HOME}/.Xauthority \
+    && chown -R $DOCKER_USER:$DOCKER_USER ${HOME}/.Xauthority
+
+# Set display resolution (change as needed)
+ENV RESOLUTION=1024x780
+
+ENV DISPLAY=:1
+
+# Expose VNC port
+EXPOSE 5901
+
+# VNC support
+RUN apt update && apt upgrade -y && apt install -y  --no-install-recommends\
+    tightvncserver
+
+RUN apt update && apt upgrade -y && apt install -y  --no-install-recommends\
+    xterm
+
+# Setup VNC server
+RUN mkdir ${HOME}/.vnc \
+    && echo "password" | vncpasswd -f > ${HOME}/.vnc/passwd \
+    && chmod 600 ${HOME}/.vnc/passwd \
+    && chown -R $DOCKER_USER:$DOCKER_USER ${HOME}/.vnc
+    
+# Copy a script to start the VNC server
+COPY scripts/start-vnc.sh ${HOME}/
+RUN chmod +x ${HOME}/start-vnc.sh
+
+# additionnal helper build scripts
+COPY scripts/tycho_build.sh ${HOME}/
+RUN chmod a+x ${HOME}/tycho_build.sh
+COPY scripts/pomfirst_build.sh ${HOME}/
+RUN chmod a+x ${HOME}/pomfirst_build.sh
+COPY scripts/generate_protocols.sh ${HOME}/
+RUN chmod a+x ${HOME}/generate_protocols.sh
+
+RUN chown -R $DOCKER_USER:$DOCKER_USER ${HOME}
+
+
+
+
+# some cleanup
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# switch to default user
+#USER 1000
+WORKDIR ${HOME}
+
+#RUN useradd -u 1000 -ms /bin/bash ci
+#RUN useradd -r -u 1000 -g ci ci
+
+# explicitly set locale
+ENV LANG=en_US.UTF-8
+
+
+#USER ci
+
+#ENTRYPOINT ["bash", "./entrypoint.sh"]
+

--- a/dev_support/gemoc_builder/docker/cache-m2/.gitignore
+++ b/dev_support/gemoc_builder/docker/cache-m2/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all files in this dir...
+*
+
+# ... except for this one.
+!.gitignore

--- a/dev_support/gemoc_builder/docker/log/.gitignore
+++ b/dev_support/gemoc_builder/docker/log/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all files in this dir...
+*
+
+# ... except for this one.
+!.gitignore

--- a/dev_support/gemoc_builder/docker/scripts/entrypoint
+++ b/dev_support/gemoc_builder/docker/scripts/entrypoint
@@ -17,6 +17,7 @@ fi
 
 if [ "$UID" != 0 ]
 then
+		echo "entrypoint: using gosu to run command as $DOCKER_USER"
         usermod -u "$UID" "$DOCKER_USER" 2>/dev/null && {
                 groupmod -g "$GID" "$DOCKER_USER" 2>/dev/null ||
                 usermod -a -G "$GID" "$DOCKER_USER"

--- a/dev_support/gemoc_builder/docker/scripts/entrypoint
+++ b/dev_support/gemoc_builder/docker/scripts/entrypoint
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+
+#cf. https://stackoverflow.com/questions/57776452/is-it-possible-to-map-a-user-inside-the-docker-container-to-an-outside-user
+
+
+#!/bin/sh
+  
+set -e
+set -u
+
+: "${UID:=0}"
+: "${GID:=${UID}}"
+
+if [ "$#" = 0 ]
+then set -- "$(command -v bash 2>/dev/null || command -v sh)" -l
+fi
+
+if [ "$UID" != 0 ]
+then
+        usermod -u "$UID" "$DOCKER_USER" 2>/dev/null && {
+                groupmod -g "$GID" "$DOCKER_USER" 2>/dev/null ||
+                usermod -a -G "$GID" "$DOCKER_USER"
+        }
+        set -- gosu "${UID}:${GID}" "${@}"
+fi
+
+exec "$@"

--- a/dev_support/gemoc_builder/docker/scripts/generate_protocols.sh
+++ b/dev_support/gemoc_builder/docker/scripts/generate_protocols.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo arguments seen: $1
+
+cd $HOME/src/gemoc-studio-modeldebugging/protocols/generators/ts/JSONSchema2APIProtocolGenerator
+
+pwd
+
+if [ -z "$1" ]
+then
+	echo "---------- generate protocols classes -----------"
+	npm config ls
+	npm install
+	npm run build
+	npm run generate
+else
+	case $1 in
+	"full") 
+		echo "-------- compile full gemoc studio (and install in .m2) --------"
+		npm config ls
+		npm install
+		npm run build
+		npm run generate;;
+	*)		
+		echo "command $1 not recognized, possible arguments: full" ;;
+	esac
+fi
+

--- a/dev_support/gemoc_builder/docker/scripts/pomfirst_build.sh
+++ b/dev_support/gemoc_builder/docker/scripts/pomfirst_build.sh
@@ -2,6 +2,9 @@
 
 echo arguments seen: $1
 
+id -a
+echo HOME=$HOME
+
 cd $HOME/src/gemoc-studio/dev_support/pomfirst_full_compilation/
 
 pwd

--- a/dev_support/gemoc_builder/docker/scripts/pomfirst_build.sh
+++ b/dev_support/gemoc_builder/docker/scripts/pomfirst_build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo arguments seen: $1
+
+cd $HOME/src/gemoc-studio/dev_support/pomfirst_full_compilation/
+
+pwd
+
+if [ -z "$1" ]
+then
+	echo "---------- compile gemoc pomfirst (clean verify) -----------"
+	mvn clean verify --errors  --show-version
+else
+	case $1 in
+	"full") 
+		echo "-------- compile gemoc pomfirst (and install in .m2) --------"
+		mvn -Dmaven.test.failure.ignore \
+			dependency:tree dependency:analyze dependency:analyze-dep-mgt \
+			clean install \
+			--errors --show-version --batch-mode;;
+	"clean") 
+		echo "-------- clean --------"
+		mvn clean --errors  --show-version  --batch-mode;;
+	*)		
+		echo "command $1 not recognized, possible arguments: full, clean" ;;
+	esac
+fi
+

--- a/dev_support/gemoc_builder/docker/scripts/start-vnc.sh
+++ b/dev_support/gemoc_builder/docker/scripts/start-vnc.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#echo 'Updating /etc/hosts file...'
+#HOSTNAME=$(hostname)
+#echo "127.0.1.1\t$HOSTNAME" >> /etc/hosts
+
+export USER=`whoami`
+echo "USER=$USER"
+
+echo "Starting VNC server at $RESOLUTION..."
+vncserver -kill $DISPLAY || true
+vncserver -geometry $RESOLUTION -depth 16 $DISPLAY &

--- a/dev_support/gemoc_builder/docker/scripts/tycho_build.sh
+++ b/dev_support/gemoc_builder/docker/scripts/tycho_build.sh
@@ -27,20 +27,26 @@ else
 		echo "-------- clean --------"
 		mvn clean --errors  --show-version;;
 	"linux") 
-		echo "-------- compile gemoc studio for linux only in online (install in .m2) --------"
-		mvn -P test_linux clean install --errors  --show-version;;
+		echo "-------- compile gemoc studio for linux only in online  --------"
+		mvn -P test_linux clean install --errors  --show-version --batch-mode;;
 	"linux_no_system_test") 
-		echo "-------- compile gemoc studio for linux only no system tests, online, install in .m2 --------"
-		mvn -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb    clean install --errors  --show-version;;	
+		echo "-------- compile gemoc studio for linux only no system tests, online --------"
+		mvn -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb  \
+									-Djava.awt.headless=true \
+									clean verify \
+									--errors  --show-version --batch-mode;;	
     "linux_no_system_test_offline") 
 		echo "-------- compile gemoc studio for linux only no system tests, offline, install in .m2 --------"
-		mvn -o -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb  clean install --errors  --show-version;;	
+		mvn -o -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb  \
+									-Djava.awt.headless=true \
+									clean install \
+									--errors  --show-version;;	
 	"linux_offline") 
 		echo "-------- compile gemoc studio for linux only (offline) (install in .m2) --------"
 		mvn -o -P test_linux clean install --errors  --show-version;;
 	"linux_system_test_only") 
 		echo "-------- running system tests only ------------"
-		mvn -P test_linux --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb,../../gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform clean verify --errors  --show-version;;
+		mvn -P test_linux -Dmaven.test.failure.ignore --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb,../../gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform clean verify --errors  --show-version;;
 	"tycho_dependencies") 
 		echo "-------- show tycho dependencies  ------------"
 		mvn -P test_linux org.eclipse.tycho:tycho-p2-plugin:dependency-tree;;

--- a/dev_support/gemoc_builder/docker/scripts/tycho_build.sh
+++ b/dev_support/gemoc_builder/docker/scripts/tycho_build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+echo arguments seen: $1
+
+#Xvfb :99 &
+#export DISPLAY=:99
+
+#$HOME/.vnc/xstartup.sh
+
+$HOME/start-vnc.sh
+
+
+cd $HOME/src/gemoc-studio/dev_support/tycho_full_compilation/
+
+pwd
+
+if [ -z "$1" ]
+then
+	echo "---------- compile full gemoc studio (clean verify) -----------"
+	mvn clean verify --errors  --show-version
+else
+	case $1 in
+	"full") 
+		echo "-------- compile full gemoc studio (and install in .m2) --------"
+		mvn clean install --errors  --show-version;;
+	"clean") 
+		echo "-------- clean --------"
+		mvn clean --errors  --show-version;;
+	"linux") 
+		echo "-------- compile gemoc studio for linux only in online (install in .m2) --------"
+		mvn -P test_linux clean install --errors  --show-version;;
+	"linux_no_system_test") 
+		echo "-------- compile gemoc studio for linux only no system tests, online, install in .m2 --------"
+		mvn -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb    clean install --errors  --show-version;;	
+    "linux_no_system_test_offline") 
+		echo "-------- compile gemoc studio for linux only no system tests, offline, install in .m2 --------"
+		mvn -o -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb  clean install --errors  --show-version;;	
+	"linux_offline") 
+		echo "-------- compile gemoc studio for linux only (offline) (install in .m2) --------"
+		mvn -o -P test_linux clean install --errors  --show-version;;
+	"linux_system_test_only") 
+		echo "-------- running system tests only ------------"
+		mvn -P test_linux --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb,../../gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform clean verify --errors  --show-version;;
+	"tycho_dependencies") 
+		echo "-------- show tycho dependencies  ------------"
+		mvn -P test_linux org.eclipse.tycho:tycho-p2-plugin:dependency-tree;;
+	*)		
+		echo "command $1 not recognized, possible arguments: full, clean, linux, linux_system_test_only, linux_no_system_test, linux_no_system_test_offline, linux_offline, tycho_dependencies" ;;
+	esac
+fi
+

--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -1,6 +1,10 @@
 FROM eclipsecbi/jiro-agent-centos-8:remoting-3107.v665000b_51092
 # based on https://github.com/eclipse-cbi/jiro-agents/blob/master/centos-8/Dockerfile
 
+ARG MAVEN_VERSION=3.9.8
+ARG MAVEN_BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+
 # Switch to root user
 USER root
 
@@ -29,12 +33,23 @@ RUN alternatives --install /usr/bin/java java /usr/lib/jvm/java-17-openjdk/bin/j
   && alternatives --set java /usr/lib/jvm/java-17-openjdk/bin/java
 RUN alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-17-openjdk/bin/javac 1000 --family java-17-openjdk.x86_64 \
   && alternatives --set javac /usr/lib/jvm/java-17-openjdk/bin/javac
+  
+# Define commonly used JAVA_HOME variable
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk/
 
 RUN wget https://download2.gluonhq.com/openjfx/17.0.2/openjfx-17.0.2_linux-x64_bin-sdk.zip  -O ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip 
 RUN unzip ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip -d /usr/share/
 RUN rm ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip 
 
 ENV JAVAFX_HOME=/usr/share/javafx-sdk-17.0.2
+
+# install maven (not used in jenkins due to toolchain.xml)
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+ && curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+ && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+ && rm -f /tmp/apache-maven.tar.gz \
+ && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ENV MAVEN_HOME /usr/share/maven
 
 # install memory monitor script file
 COPY scripts/memory-monitor/memory-monitor-per-process.py ${HOME}/memory-monitor-per-process.py

--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -51,6 +51,12 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 ENV MAVEN_HOME /usr/share/maven
 
+
+# used to have ts to have console timestamps cf. https://unix.stackexchange.com/questions/26728/prepending-a-timestamp-to-each-line-of-output-from-a-command
+RUN dnf install -y \
+    moreutils \
+  && dnf clean all
+
 # install memory monitor script file
 COPY scripts/memory-monitor/memory-monitor-per-process.py ${HOME}/memory-monitor-per-process.py
 RUN python3 -m pip install psutil

--- a/dev_support/jenkins/docker/Dockerfile
+++ b/dev_support/jenkins/docker/Dockerfile
@@ -1,10 +1,6 @@
 FROM eclipsecbi/jiro-agent-centos-8:remoting-3107.v665000b_51092
 # based on https://github.com/eclipse-cbi/jiro-agents/blob/master/centos-8/Dockerfile
 
-ARG MAVEN_VERSION=3.9.8
-ARG MAVEN_BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-
 # Switch to root user
 USER root
 
@@ -33,29 +29,12 @@ RUN alternatives --install /usr/bin/java java /usr/lib/jvm/java-17-openjdk/bin/j
   && alternatives --set java /usr/lib/jvm/java-17-openjdk/bin/java
 RUN alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-17-openjdk/bin/javac 1000 --family java-17-openjdk.x86_64 \
   && alternatives --set javac /usr/lib/jvm/java-17-openjdk/bin/javac
-  
-# Define commonly used JAVA_HOME variable
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk/
 
 RUN wget https://download2.gluonhq.com/openjfx/17.0.2/openjfx-17.0.2_linux-x64_bin-sdk.zip  -O ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip 
 RUN unzip ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip -d /usr/share/
 RUN rm ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip 
 
 ENV JAVAFX_HOME=/usr/share/javafx-sdk-17.0.2
-
-# install maven (not used in jenkins due to toolchain.xml)
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
- && curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
- && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
- && rm -f /tmp/apache-maven.tar.gz \
- && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-ENV MAVEN_HOME /usr/share/maven
-
-
-# used to have ts to have console timestamps cf. https://unix.stackexchange.com/questions/26728/prepending-a-timestamp-to-each-line-of-output-from-a-command
-RUN dnf install -y \
-    moreutils \
-  && dnf clean all
 
 # install memory monitor script file
 COPY scripts/memory-monitor/memory-monitor-per-process.py ${HOME}/memory-monitor-per-process.py

--- a/dev_support/jenkins/docker/README.asciidoc
+++ b/dev_support/jenkins/docker/README.asciidoc
@@ -56,7 +56,7 @@ Start system tests (UI) from the container:
 ```
 ~/.vnc/xstartup.sh
 cd src/gemoc-studio/dev_support/tycho_full_compilation/
-mvn --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb verify
+mvn --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb,../../gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform verify
 ```
 
 connect to vncserver display from your host using a vnc viewer (for example using remmina) on `localhost:5900` (the password is `123456`)

--- a/dev_support/jenkins/docker/README.asciidoc
+++ b/dev_support/jenkins/docker/README.asciidoc
@@ -30,10 +30,19 @@ docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenk
 docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 -p 5900:5900 gemoc/gemoc-jenkins-fat-agent:latest /bin/bash
 ----
 
+Generate protocal classes from the container
+
+```
+cd /home/jenkins/src/gemoc-studio-modeldebugging/protocols/generators/ts/JSONSchema2APIProtocolGenerator
+npm install
+npm run build
+npm run generate
+```
+
 Build the studio (no test) from the container
 
 ```
-cd src/gemoc-studio/dev_support/full_compilation/
+cd /home/jenkins/src/gemoc-studio/dev_support/tycho_full_compilation/
 mvn -DskipTests=true -Djava.awt.headless=true -P test_linux install
 ```
 
@@ -41,11 +50,11 @@ mvn -DskipTests=true -Djava.awt.headless=true -P test_linux install
 Start system tests (UI) from the container:
 ```
 ~/.vnc/xstartup.sh
-cd src/gemoc-studio/dev_support/full_compilation/
+cd src/gemoc-studio/dev_support/tycho_full_compilation/
 mvn --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb verify
 ```
 
-connect to vncserver display from your host using a vnc viewer(for example using remmina) on `localhost:5900` (the password is `123456`)
+connect to vncserver display from your host using a vnc viewer (for example using remmina) on `localhost:5900` (the password is `123456`)
 
 
  

--- a/dev_support/jenkins/docker/README.asciidoc
+++ b/dev_support/jenkins/docker/README.asciidoc
@@ -47,6 +47,11 @@ mvn -DskipTests=true -Djava.awt.headless=true -P test_linux install
 ```
 
 
+With timestamped log file
+```
+mvn -DskipTests=true -Djava.awt.headless=true -P test_linux install | ts -s | tee -a /home/jenkins/src/tycho_full_compilation.log
+```
+
 Start system tests (UI) from the container:
 ```
 ~/.vnc/xstartup.sh

--- a/dev_support/tycho_full_compilation/README.asciidoc
+++ b/dev_support/tycho_full_compilation/README.asciidoc
@@ -199,7 +199,11 @@ docker compose run gemoc_full_compilation /bin/bash
 or 
 [source,bourne]
 ----
-docker run -it -v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) gemoc/gemoc-full-compilation:latest /bin/bash
+docker run -it --rm \
+-v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 \
+--publish 5900:5900 \
+--env UID=$(id -u) --env GID=$(id -g) \
+gemoc/gemoc-full-compilation:latest /bin/bash
 ----
    
 

--- a/dev_support/tycho_full_compilation/README.asciidoc
+++ b/dev_support/tycho_full_compilation/README.asciidoc
@@ -88,7 +88,7 @@ You can save some time on the compilation in development mode using some of the 
 
 [NOTE]
 ====
-The current versio compiles using Java11 and Java FX.
+The current version compiles using Java17 and Java FX.
 You need to indicate the location of javafx using an environment variable JAVAFX_HOME indicating the location of your java fx installation.
 ====
 
@@ -105,7 +105,7 @@ To do a full build using docker: go to the docker folder (*/gemoc-studio/dev_sup
 
 [source,bourne]
 ----
-docker-compose down && docker-compose up
+docker compose down && docker compose up
 ----
  or
  
@@ -119,67 +119,89 @@ Changes commited in master branch are automatically built and deployed on docker
 
 
 ===== Manual launch
-A standard full build is done using the command:
+A standard build (mvn clean verify) is done using the `docker compose` command:
+
 [source,bourne]
 ----
-docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 gemoc/gemoc-full-compilation:latest ./build_gemoc.sh
+docker compose run gemoc_full_compilation ./build_gemoc.sh
+----
+
+or the `docker` command
+
+[source,bourne]
+----
+docker run -it -v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) gemoc/gemoc-full-compilation:latest ./build_gemoc.sh
 ---- 
 
 where
  
-- $PWD/../../../.. points to the root containing all gemoc sources
-- --user 1000  makes sure to use your user uid (use `id -u` or `echo $UID`to get yours user uid if this isn't 1000) 
+- `$PWD/../../../..` points to the root containing all gemoc sources (this suppose that you run the script from the folder containing the `docker-compose.yml` file)
+- `--env UID=$(id -u) --env GID=$(id -g)`  makes sure to use your user uid (use `id -u` or `echo $UID`to get yours user uid if this isn't 1000) 
 
 note: you must create the _$PWD/cache-m2_ folder before launching the docker command in order to avoid permission issues.
 
 
 
-Once the full compilation has been done at least once (ie. and filled the m2 cache), you can run the system test only using the command
+Once the full compilation has been done at least once (ie. target folders contain the jars and the m2 cache is populated), you can limit the build to some predefined subset defined in `build_gemoc.sh` by adding one of the following argument:
+
+- `full` -> mvn clean install
+- `clean` -> mvn clean
+- `linux` compile gemoc studio for linux only in online (install in .m2)
+- `linux_no_system_test` compile gemoc studio for linux only no system tests, online, install in .m2
+- `linux_no_system_test_offline` compile gemoc studio for linux only no system tests, offline, install in .m2
+- `linux_offline` compile gemoc studio for linux only (offline) (install in .m2)
+- `linux_system_test_only` running system tests only
+- `tycho_dependencies` display the plugin dependencies computed by tycho
+
+
+   
+TIP: you can timestamp the console and save in a local log by adding `|& ts -s |& tee build.log` at the end of the command (where `ts` comes from the the `moreutils` package)
+
+
+examples
 [source,bourne]
 ----
-docker-compose run gemoc_full_compilation system_test_only
+docker compose run gemoc_full_compilation ./build_gemoc.sh clean |& ts -s |& tee log/clean.log
+docker compose run gemoc_full_compilation ./build_gemoc.sh linux_no_system_test |& ts -s |& tee log/linux_no_system_test.log
+docker compose run gemoc_full_compilation ./build_gemoc.sh linux_no_system_test_offline |& ts -s |& tee log/linux_no_system_test_offline.log
+docker compose run gemoc_full_compilation ./build_gemoc.sh linux_system_test_only |& ts -s |& tee log/linux_system_test_only.log
 ----
 
-Or you can run a full build but including only the linux variant using:
-[source,bourne]
-----
-docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 gemoc/gemoc-full-compilation:latest ./build_gemoc.sh linux
----- 
-or
-[source,bourne]
-----
-docker-compose run gemoc_full_compilation linux_offline
-----
 
-or
-[source,bourne]
-----
-docker-compose run gemoc_full_compilation linux_no_system_test
-----
-or
-[source,bourne]
-----
-docker-compose run gemoc_full_compilation linux_no_system_test_offline
-----
 
 ===== Description of the docker env
 
-The _Dockerfile_ defines a docker image based on ubuntu 16.04 with maven, oracle java8, xvfb, and graphviz. It embeds an *entrypoint.sh* script that calls the maven command.
-The _docker-compose.yml_ will mount the folder containing all gemoc repositories (ie. the place where you've done `git clone`) 
-It also mounts a *cache-m2* folder in order to speed up the compilation.
+The _Dockerfile_ defines a docker image based on ubuntu 24.04 with maven, oracle java17, xvfb, and graphviz. It embeds an *entrypoint.sh* script that allows to run using your own userId. (To avoid issue about file created as root instead of your local uid, it uses `gosu`  in the entrypoint script (cf. https://stackoverflow.com/questions/57776452/is-it-possible-to-map-a-user-inside-the-docker-container-to-an-outside-user))
 
-The docker-compose command is more or less equivalent to:
+The _docker-compose.yml_ will mount the folder containing all gemoc repositories (ie. the place where you've done `git clone`) 
+
+It also mounts a *cache-m2* folder in order to speed up successive compilations.
+
+The `docker compose run gemoc_full_compilation ./build_gemoc.sh` command is more or less equivalent to:
 [source,bourne]
 ----
 docker build -t gemoc/gemoc-full-compilation:latest .
-docker run -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 gemoc/gemoc-full-compilation:latest
+docker run -v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=1000 --env GID=1000 gemoc/gemoc-full-compilation:latest ./build_gemoc.sh
 ----
 
 Then you'll have to manually prune unused containers after usage.
 
-If for some reason you wish to access it interactively you can use the following command:
+
+===== Interactive access
+
+If for some reason you wish to access it interactively you can use the following commands:
+
 [source,bourne]
 ----
-docker run -it -v $PWD/../../../..:/home/jenkins/src -v $PWD/cache-m2:/home/jenkins/.m2 --user 1000 gemoc/gemoc-full-compilation:latest /bin/bash
+docker compose run gemoc_full_compilation /bin/bash
 ----
+
+or 
+[source,bourne]
+----
+docker run -it -v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) gemoc/gemoc-full-compilation:latest /bin/bash
+----
+   
+
+ 
    

--- a/dev_support/tycho_full_compilation/docker/Dockerfile
+++ b/dev_support/tycho_full_compilation/docker/Dockerfile
@@ -19,19 +19,36 @@
 ###############################################################
 
 
-FROM ubuntu:16.04
+FROM ubuntu:24.04
 
-### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
-COPY scripts/uid_entrypoint /usr/local/bin/uid_entrypoint
-RUN chmod u+x /usr/local/bin/uid_entrypoint && \
-    chgrp 0 /usr/local/bin/uid_entrypoint && \
-    chmod g=u /usr/local/bin/uid_entrypoint /etc/passwd
-ENTRYPOINT [ "uid_entrypoint" ]
+ARG MAVEN_VERSION=3.9.8
+ARG MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
+
+ARG DOCKER_USER=ubuntu
+
+# ubuntu user already exists in base image
+#RUN groupadd  $DOCKER_USER
+#RUN useradd  -ms /bin/bash -d /home/$DOCKER_USER -g $DOCKER_USER $DOCKER_USER
+
+#RUN addgroup "$DOCKER_USER" \
+# 	&& adduser "$DOCKER_USER" -G "$DOCKER_USER"
+ 
+RUN apt update && apt upgrade -y && apt install -y  --no-install-recommends \
+	gosu
+
+COPY scripts/entrypoint /entrypoint
+RUN chmod 0755 /entrypoint \
+	&& sed "s/\$DOCKER_USER/$DOCKER_USER/g" -i /entrypoint
+#RUN chmod u+x /usr/local/bin/uid_entrypoint && \
+#    chgrp 0 /usr/local/bin/uid_entrypoint && \
+#    chmod g=u /usr/local/bin/uid_entrypoint /etc/passwd
+ENTRYPOINT [ "/entrypoint" ]
 
 #ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-	libgtk-3-0=3.18.* \
+# 	libgtk-3-0=3.18.* 
+
+RUN apt update && apt upgrade -y && apt install -y  --no-install-recommends\
 	language-pack-en-base \
 	metacity \
 	x11-xserver-utils \
@@ -44,16 +61,34 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	fonts-freefont-ttf \
 	fonts-dejavu \
 	fonts-dejavu-core \
-	fonts-dejavu-extra
+	fonts-dejavu-extra \
+	moreutils \
+	zip \
+	unzip \
+	curl \
+	wget
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt update && apt install -y   --no-install-recommends \
 	graphviz \
 	xvfb 
 
 RUN apt-get install -y  --no-install-recommends \
-	openjdk-11-jdk \
-	openjfx \
-	maven
+	openjdk-17-jdk \
+	openjfx 
+
+RUN wget https://download2.gluonhq.com/openjfx/17.0.2/openjfx-17.0.2_linux-x64_bin-sdk.zip  -O ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip 
+RUN unzip ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip -d /usr/share/
+RUN rm ${HOME}/openjfx-17.0.2_linux-x64_bin-sdk.zip 
+
+ENV JAVAFX_HOME=/usr/share/javafx-sdk-17.0.2
+	
+# install maven 
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+ && curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+ && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+ && rm -f /tmp/apache-maven.tar.gz \
+ && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ENV MAVEN_HOME=/usr/share/maven
 
 RUN apt-get install -y  --no-install-recommends \	
 	dbus
@@ -67,7 +102,7 @@ RUN apt-get install -y \
 # some cleanup
 RUN rm -rf /var/lib/apt/lists/*
 
-ENV HOME=/home/jenkins
+ENV HOME=/home/$DOCKER_USER
 
 # avoid "library appears to be incorrectly set up; failed to read machine uuid: UUID file '/etc/machine-id' should contain a hex string of length 32" when launching x 
 # cf http://www.torkwrench.com/2011/12/16/d-bus-library-appears-to-be-incorrectly-set-up-failed-to-read-machine-uuid-failed-to-open-varlibdbusmachine-id/ and https://github.com/activatedgeek/docker-videostack/issues/1
@@ -83,7 +118,7 @@ RUN mkdir /tmp/.X11-unix && \
 	chown root /tmp/.X11-unix/
 # probably not required during image build
 RUN Xvfb :99 &
-ENV DISPLAY :99
+ENV DISPLAY=:99
 
 
 
@@ -93,7 +128,7 @@ RUN chmod a+x ${HOME}/build_gemoc.sh
 
 
 # switch to default user
-USER 10001
+#USER 1000
 WORKDIR ${HOME}
 
 #RUN useradd -u 1000 -ms /bin/bash ci

--- a/dev_support/tycho_full_compilation/docker/docker-compose.yml
+++ b/dev_support/tycho_full_compilation/docker/docker-compose.yml
@@ -2,7 +2,10 @@ services:
   gemoc_full_compilation:
     image: "gemoc/gemoc-full-compilation:latest"
     build: "."
+    environment:
+      UID: 1000
+      GID: 1000
     volumes:
-      - "./cache-m2:/home/jenkins/.m2"
-      - "../../../..:/home/jenkins/src"
+      - "./cache-m2:/home/ubuntu/.m2"
+      - "../../../..:/home/ubuntu/src"
       

--- a/dev_support/tycho_full_compilation/docker/docker-compose.yml
+++ b/dev_support/tycho_full_compilation/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   gemoc_full_compilation:
     image: "gemoc/gemoc-full-compilation:latest"

--- a/dev_support/tycho_full_compilation/docker/entrypoint.sh
+++ b/dev_support/tycho_full_compilation/docker/entrypoint.sh
@@ -10,7 +10,7 @@ cd /root/src/gemoc-studio
 if [ -z "$1" ]
 then
 	echo "---------- compile full gemoc studio -----------"
-	mvn -f /root/src/gemoc-studio/dev_support/full_compilation/pom.xml clean install --errors
+	mvn -f /root/src/gemoc-studio/dev_support/tycho_full_compilation/pom.xml clean install --errors
 else
 	case $1 in
 	"full") 

--- a/dev_support/tycho_full_compilation/docker/log/.gitignore
+++ b/dev_support/tycho_full_compilation/docker/log/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all files in this dir...
+*
+
+# ... except for this one.
+!.gitignore

--- a/dev_support/tycho_full_compilation/docker/scripts/build_gemoc.sh
+++ b/dev_support/tycho_full_compilation/docker/scripts/build_gemoc.sh
@@ -7,7 +7,7 @@ export DISPLAY=:99
 
 #$HOME/.vnc/xstartup.sh
 
-cd $HOME/src/gemoc-studio/dev_support/full_compilation/
+cd $HOME/src/gemoc-studio/dev_support/tycho_full_compilation/
 
 pwd
 
@@ -20,6 +20,9 @@ else
 	"full") 
 		echo "-------- compile full gemoc studio (and install in .m2) --------"
 		mvn clean install --errors  --show-version;;
+	"clean") 
+		echo "-------- clean --------"
+		mvn clean --errors  --show-version;;
 	"linux") 
 		echo "-------- compile gemoc studio for linux only in online (install in .m2) --------"
 		mvn -P test_linux clean install --errors  --show-version;;
@@ -34,9 +37,12 @@ else
 		mvn -o -P test_linux clean install --errors  --show-version;;
 	"linux_system_test_only") 
 		echo "-------- running system tests only ------------"
-		mvn -P test_linux --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb verify --errors  --show-version;;
+		mvn -P test_linux --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb,../../gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform clean verify --errors  --show-version;;
+	"tycho_dependencies") 
+		echo "-------- show tycho dependencies  ------------"
+		mvn -P test_linux org.eclipse.tycho:tycho-p2-plugin:dependency-tree;;
 	*)		
-		echo "command $1 not recognized, possible arguments: linux_system_test_only, linux_no_system_test, linux_no_system_test_offline, full, linux_offline" ;;
+		echo "command $1 not recognized, possible arguments: full, clean, linux, linux_system_test_only, linux_no_system_test, linux_no_system_test_offline, linux_offline, tycho_dependencies" ;;
 	esac
 fi
 

--- a/dev_support/tycho_full_compilation/docker/scripts/entrypoint
+++ b/dev_support/tycho_full_compilation/docker/scripts/entrypoint
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+
+#cf. https://stackoverflow.com/questions/57776452/is-it-possible-to-map-a-user-inside-the-docker-container-to-an-outside-user
+
+
+#!/bin/sh
+  
+set -e
+set -u
+
+: "${UID:=0}"
+: "${GID:=${UID}}"
+
+if [ "$#" = 0 ]
+then set -- "$(command -v bash 2>/dev/null || command -v sh)" -l
+fi
+
+if [ "$UID" != 0 ]
+then
+        usermod -u "$UID" "$DOCKER_USER" 2>/dev/null && {
+                groupmod -g "$GID" "$DOCKER_USER" 2>/dev/null ||
+                usermod -a -G "$GID" "$DOCKER_USER"
+        }
+        set -- gosu "${UID}:${GID}" "${@}"
+fi
+
+exec "$@"

--- a/dev_support/tycho_full_compilation/docker/scripts/uid_entrypoint
+++ b/dev_support/tycho_full_compilation/docker/scripts/uid_entrypoint
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-: "${USERNAME:="default"}"
-
-if ! whoami &> /dev/null; then
-  if [ -w /etc/passwd ]; then
-    echo "${USERNAME}:x:$(id -u):0:${USERNAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
-  fi
-fi
-exec "$@"


### PR DESCRIPTION
## Description

Add a new docker image allowing to run the various build and test tasks locally.
It will also be used in an alternative CI (based on docker action and optionnaly with internally hosted runner so we may overcome the issue of the 4GB of ram proposed by the jenkins infrastructure

The image features:
- a VNC server allowing to connect/disconnect the display without interference with the developer PC (and thus help investigating the integration test issues )
- management of user id, so the files generated by the compilation can be mixed with the host PC (allow mapping of the uid:gid)
- build script for the common tasks (protocol generation, tycho build and test, pomfirt build)
- contains all required tooling, graphviz, nodejs, java 17, maven
- based on ubuntu 24.04 with display manager = sddm, window manager = openbox,  no desktop 

currently (manually) deployed on dockerhub using this name: `gemoc/gemoc-builder:latest`


## Contribution to issues

Contribute to #316   

