### PR TITLE
Improve tycho_build.sh to help local debug with the docker image

### DIFF
--- a/dev_support/gemoc_builder/README.asciidoc
+++ b/dev_support/gemoc_builder/README.asciidoc
@@ -32,16 +32,18 @@ docker build -t "gemoc/gemoc-builder:2024-08-02" .
 
 ===== Interactive usage
 
-```
+[source,bourne]
+----
 docker run -it --rm --name gemoc-builder -v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" /bin/bash
-```
+----
 
 
-Optionnaly, open the GUI (useful for graphical integration tests)
+Optionnaly, open the GUI (useful for graphical integration tests) (vnc password in the image is `password`)
 
-```
+[source,bourne]
+----
 vncviewer localhost:5901
-```
+----
 
 Where:
 
@@ -56,15 +58,20 @@ The image contains several build scripts for various common usages.
 - `generate_protocols.sh` with the possible arguments
 ** `full` -> npm install; npm run build; npm run generate
 
-- `tycho_build.sh` with the possible arguments
-** `full` -> mvn clean install
-** `clean` -> mvn clean
-** `linux` compile gemoc studio for linux only, online, install in .m2
-** `linux_no_system_test` compile gemoc studio for linux only no system tests, online, install in .m2
-** `linux_no_system_test_offline` compile gemoc studio for linux only no system tests, offline, install in .m2
-** `linux_offline` compile gemoc studio for linux only, offline, install in .m2
-** `linux_system_test_only` running system tests only
-** `tycho_dependencies` display the plugin dependencies computed by tycho
+- `tycho_build.sh` 
+** Usage: `./tycho_build.sh [Options]* CommandName`
+** CommandName:  `full clean | no_system_test | system_test_only | tycho_dependencies`
+*** `full` -> `mvn clean install` of all projects (includes system test)
+*** `clean` -> `mvn clean`
+*** `no_system_test` -> `mvn install` of the studio except the system test projects
+*** `system_test_only` -> `mvn verify` of the system test projects
+*** `tycho_dependencies` -> display the plugin dependencies computed by tycho
+** Options: `[-b|--batch-mode] [-d|--debug] [-l|--linux] [-o|--offline] [-r|--debugResolver]`
+*** `batch-mode` -> removes colors extra char, useful when storing in file
+*** `debug` -> enable maven debug output
+*** `linux` -> restrict the build and to the linux platform
+*** `offline` -> maven work offline
+*** `debugResolver` -> enable debug and display tycho resolver debug output
 
 - `pomfirst_build.sh` with the possible arguments
 ** `full` -> mvn clean install
@@ -72,10 +79,13 @@ The image contains several build scripts for various common usages.
    
 TIP: you can timestamp the console and save in a local log by adding `|& ts -s |& tee build.log` at the end of the command (where `ts` comes from the the `moreutils` package)
 
-typicall use: (for the folder containing all the git repositories
-```
-docker run -it --rm --name gemoc-builder -v $PWD:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" ./tycho_build.sh linux |& ts -s |& tee linux_build.log
-```
+typical use: (from the folder containing all the git repositories
+
+
+[source,bourne]
+----
+docker run -it --rm --name gemoc-builder -v $PWD:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" ./tycho_build.sh --linux full |& ts -s |& tee linux_full_build.log
+----
 
 ===== Description of the docker env
 

--- a/dev_support/gemoc_builder/docker/scripts/tycho_build.sh
+++ b/dev_support/gemoc_builder/docker/scripts/tycho_build.sh
@@ -1,6 +1,66 @@
 #!/bin/bash
 
-echo arguments seen: $1
+
+
+
+# Initialize variables for options
+optionOffline=
+optionDebug=
+optionLinux=
+optionDebugResolver=
+optionBatchMode=
+
+printUsage() {
+	echo "Usage: $0 [-b|--batch-mode] [-d|--debug] [-l|--linux] [-o|--offline] [-r|--debugResolver] CommandName"
+	echo "   CommandName = full, clean, no_system_test, system_test_only, tycho_dependencies "
+}
+
+# Parse options
+while getopts ":-:bdlor" opt; do
+  case $opt in
+    b) optionBatchMode="--batch-mode" ;;
+    d) optionDebug="--debug" ;;
+    l) optionLinux="-P test_linux" ;;
+    o) optionOffline="--offline" ;;
+    r) optionDebug="--debug"
+       optionDebugResolver="-Dtycho.debug.resolver=true" ;;
+    -)
+      case "${OPTARG}" in
+        batch-mode)
+            optionBatchMode="--batch-mode"  ;;
+        debug)
+            optionDebug="--debug" ;;
+        linux)
+            optionLinux="-P test_linux" ;;
+        offline)
+            optionOffline="--offline"  ;;
+        debugResolver)
+            optionDebug="--debug"
+            optionDebugResolver="-Dtycho.debug.resolver=true" ;;
+        *) echo "Unknown option --${OPTARG}"; printUsage; exit 1 ;;
+      esac
+    ;;
+    \?) echo "Invalid option: -$OPTARG" >&2; printUsage; exit 1 ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+# Check for mandatory command parameter
+if [ -z "$1" ]; then
+  echo "Error: CommandName is required."
+  printUsage
+  exit 1
+fi
+
+commandName=$1
+
+## Start script logic
+
+
+
+echo commandName seen: $1
+echo "options: optionLinux=${optionLinux} optionOffline=${optionOffline}  optionDebug=${optionDebug}   optionDebugResolver=${optionDebugResolver} optionBatchMode=${optionBatchMode}"
 
 #Xvfb :99 &
 #export DISPLAY=:99
@@ -14,44 +74,35 @@ cd $HOME/src/gemoc-studio/dev_support/tycho_full_compilation/
 
 pwd
 
-if [ -z "$1" ]
-then
-	echo "---------- compile full gemoc studio (clean verify) -----------"
-	mvn clean verify --errors  --show-version
-else
-	case $1 in
+
+
+case "${commandName}" in
 	"full") 
 		echo "-------- compile full gemoc studio (and install in .m2) --------"
-		mvn clean install --errors  --show-version;;
-	"clean") 
+		mvn ${optionLinux} ${optionOffline}  ${optionDebug}   ${optionDebugResolver} clean install --errors  --show-version ${optionBatchMode} ;;
+	"clean")
 		echo "-------- clean --------"
 		mvn clean --errors  --show-version;;
-	"linux") 
-		echo "-------- compile gemoc studio for linux only in online (and install in .m2)  --------"
-		mvn -P test_linux clean install --errors  --show-version --batch-mode;;
-	"linux_no_system_test") 
-		echo "-------- compile gemoc studio for linux only no system tests, online (and install in .m2) --------"
-		mvn -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb  \
-									-Djava.awt.headless=true \
-									clean install \
-									--errors  --show-version --batch-mode;;	
-    "linux_no_system_test_offline") 
-		echo "-------- compile gemoc studio for linux only no system tests, offline, install in .m2 --------"
-		mvn -o -P test_linux --projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb  \
-									-Djava.awt.headless=true \
-									clean install \
-									--errors  --show-version;;	
-	"linux_offline") 
-		echo "-------- compile gemoc studio for linux only (offline) (install in .m2) --------"
-		mvn -o -P test_linux clean install --errors  --show-version;;
-	"linux_system_test_only") 
+	"no_system_test")
+		echo "-------- compile gemoc studio no system tests (and install in .m2) --------"
+		mvn ${optionLinux} ${optionOffline}  ${optionDebug} ${optionDebugResolver}  \
+			--projects !../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,!../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb  \
+			-Djava.awt.headless=true \
+			install \
+			--errors  --show-version ${optionBatchMode};;
+	"system_test_only")
 		echo "-------- running system tests only ------------"
-		mvn -P test_linux -Dmaven.test.failure.ignore --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb,../../gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform clean verify --errors  --show-version;;
+		mvn ${optionLinux} ${optionOffline}  ${optionDebug} ${optionDebugResolver} \
+			-Dmaven.test.failure.ignore --projects ../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.lwb,../../gemoc_studio/tests/org.eclipse.gemoc.studio.tests.system.mwb,../../gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform \
+			verify \
+			--errors  --show-version  ${optionBatchMode} ;;
 	"tycho_dependencies") 
 		echo "-------- show tycho dependencies  ------------"
-		mvn -P test_linux org.eclipse.tycho:tycho-p2-plugin:dependency-tree;;
+		mvn ${optionLinux} ${optionOffline}  ${optionDebug} ${optionDebugResolver} \
+			org.eclipse.tycho:tycho-p2-plugin:dependency-tree  ${optionBatchMode} ;;
 	*)		
-		echo "command $1 not recognized, possible arguments: full, clean, linux, linux_system_test_only, linux_no_system_test, linux_no_system_test_offline, linux_offline, tycho_dependencies" ;;
-	esac
-fi
+		echo "command $commandName not recognized"
+		printUsage ;;
+esac
+
 


### PR DESCRIPTION
improve to options available for the different commands mainly for local use.


It also adds the possibility to display tycho resolver debug informations


## Description

restructure the tycho_build.sh option as follow:

- `tycho_build.sh` 
  - Usage: `./tycho_build.sh [Options]* CommandName`
  - CommandName:  `full clean | no_system_test | system_test_only | tycho_dependencies`
    - `full` -> `mvn clean install` of all projects (includes system test)
    - `clean` -> `mvn clean`
    - `no_system_test` -> `mvn install` of the studio except the system test projects
    - `system_test_only` -> `mvn verify` of the system test projects
    - `tycho_dependencies` -> display the plugin dependencies computed by tycho
  - Options: `[-b|--batch-mode] [-d|--debug] [-l|--linux] [-o|--offline] [-r|--debugResolver]`
    - `batch-mode` -> removes colors extra char, useful when storing in file
    - `debug` -> enable maven debug output
    - `linux` -> restrict the build and to the linux platform
    - `offline` -> maven work offline
    - `debugResolver` -> enable debug and display tycho resolver debug output
