### PR TITLE
Fix deprecated xtext generator

### DIFF
--- a/dev_support/gemoc_builder/README.asciidoc
+++ b/dev_support/gemoc_builder/README.asciidoc
@@ -33,15 +33,18 @@ docker build -t "gemoc/gemoc-builder:2024-08-02" .
 ===== Interactive usage
 
 ```
+[source,bourne]
+----
 docker run -it --rm --name gemoc-builder -v $PWD/../../../..:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" /bin/bash
-```
+----
 
 
 Optionnaly, open the GUI (useful for graphical integration tests)
 
-```
+[source,bourne]
+----
 vncviewer localhost:5901
-```
+----
 
 Where:
 
@@ -72,10 +75,40 @@ The image contains several build scripts for various common usages.
    
 TIP: you can timestamp the console and save in a local log by adding `|& ts -s |& tee build.log` at the end of the command (where `ts` comes from the the `moreutils` package)
 
-typicall use: (for the folder containing all the git repositories
-```
+typical use: (from the folder containing all the git repositories)
+
+[source,bourne]
+----
+mkdir cache-m2
+----
+
+build protocol classes
+
+[source,bourne]
+----
+docker run -it --rm --name gemoc-builder -v $PWD:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" ./generate_protocols.sh |& ts -s |& tee generate_protocols.log
+----
+
+build eclipse (no system tests)
+
+[source,bourne]
+----
+docker run -it --rm --name gemoc-builder -v $PWD:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" ./tycho_build.sh linux_no_system_test |& ts -s |& tee linux_build.log
+----
+
+eclipse system tests only
+
+[source,bourne]
+----
+docker run -it --rm --name gemoc-builder -v $PWD:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" ./tycho_build.sh linux_system_test_only |& ts -s |& tee linux_system_test_only.log
+----
+
+or full build (incl. system tests)
+
+[source,bourne]
+----
 docker run -it --rm --name gemoc-builder -v $PWD:/home/ubuntu/src -v $PWD/cache-m2:/home/ubuntu/.m2 --env UID=$(id -u) --env GID=$(id -g) -p 5901:5901 "gemoc/gemoc-builder:latest" ./tycho_build.sh linux |& ts -s |& tee linux_build.log
-```
+----
 
 ===== Description of the docker env
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="GEMOCStudio Target platform" sequenceNumber="1700842450">
+<target name="GEMOCStudio Target platform" sequenceNumber="1720016153">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.acceleo.feature.group" version="3.7.13.202304041222"/>
@@ -93,8 +93,8 @@
       <repository id="ajdt" location="https://download.eclipse.org/tools/ajdt/426/dev/update"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="fr.inria.aoste.timesquare.feature.feature.group" version="1.0.0.202109021545"/>
-      <repository id="timesquare" location="https://timesquare.gitlabpages.inria.fr/updatesite/2021-09-02"/>
+      <unit id="fr.inria.aoste.timesquare.feature.feature.group" version="1.0.0.202307261556"/>
+      <repository id="timesquare" location="https://timesquare.gitlabpages.inria.fr/updatesite/latest"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.ecoretools.registration.feature.feature.group" version="3.3.0.201811051325"/>
@@ -119,50 +119,50 @@
       <repository id="jetty" location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.44.v20210927"/>
     </location>
     <location includeDependencyDepth="infinite" includeDependencyScopes="compile,test" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
-    <dependencies>
-    	<dependency>
-    		<groupId>org.eclipse.jetty.osgi</groupId>
-    		<artifactId>jetty-osgi-boot</artifactId>
-    		<version>10.0.6</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.apache.aries.spifly</groupId>
-    		<artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-    		<version>1.3.4</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>com.ibm.icu</groupId>
-    		<artifactId>icu4j</artifactId>
-    		<version>70.1</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>javax.servlet</groupId>
-    		<artifactId>javax.servlet-api</artifactId>
-    		<version>3.1.0</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.eclipse.jetty.websocket</groupId>
-    		<artifactId>websocket-javax-server</artifactId>
-    		<version>10.0.6</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.eclipse.jetty.toolchain</groupId>
-    		<artifactId>jetty-javax-websocket-api</artifactId>
-    		<version>1.1.2</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.mapstruct</groupId>
-    		<artifactId>mapstruct</artifactId>
-    		<version>1.4.2.Final</version>
-    		<type>jar</type>
-    	</dependency>
-    </dependencies>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.osgi</groupId>
+          <artifactId>jetty-osgi-boot</artifactId>
+          <version>10.0.6</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.aries.spifly</groupId>
+          <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+          <version>1.3.4</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>com.ibm.icu</groupId>
+          <artifactId>icu4j</artifactId>
+          <version>70.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+          <version>3.1.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty.websocket</groupId>
+          <artifactId>websocket-javax-server</artifactId>
+          <version>10.0.6</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty.toolchain</groupId>
+          <artifactId>jetty-javax-websocket-api</artifactId>
+          <version>1.1.2</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.mapstruct</groupId>
+          <artifactId>mapstruct</artifactId>
+          <version>1.4.2.Final</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="GEMOCStudio Target platform" sequenceNumber="1720016153">
+<target name="GEMOCStudio Target platform" sequenceNumber="1720021704">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.acceleo.feature.group" version="3.7.13.202304041222"/>
@@ -94,7 +94,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="fr.inria.aoste.timesquare.feature.feature.group" version="1.0.0.202307261556"/>
-      <repository id="timesquare" location="https://timesquare.gitlabpages.inria.fr/updatesite/latest"/>
+      <repository id="timesquare" location="https://timesquare.gitlabpages.inria.fr/updatesite/2023-07-26"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.ecoretools.registration.feature.feature.group" version="3.3.0.201811051325"/>

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.tpd
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.tpd
@@ -122,7 +122,7 @@ location ajdt "https://download.eclipse.org/tools/ajdt/426/dev/update" {
 	org.eclipse.ajdt.feature.group
 }
 
-location timesquare "https://timesquare.gitlabpages.inria.fr/updatesite/latest" {
+location timesquare "https://timesquare.gitlabpages.inria.fr/updatesite/2023-07-26" {
 	fr.inria.aoste.timesquare.feature.feature.group
 }
 

--- a/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.tpd
+++ b/gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform/gemoc_studio.tpd
@@ -122,7 +122,7 @@ location ajdt "https://download.eclipse.org/tools/ajdt/426/dev/update" {
 	org.eclipse.ajdt.feature.group
 }
 
-location timesquare "https://timesquare.gitlabpages.inria.fr/updatesite/2021-09-02" {
+location timesquare "https://timesquare.gitlabpages.inria.fr/updatesite/latest" {
 	fr.inria.aoste.timesquare.feature.feature.group
 }
 

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/SpecificTrace.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/SpecificTrace.java
@@ -40,10 +40,6 @@ public interface SpecificTrace extends Trace<SequentialStep<? extends SpecificSt
 	 * Returns the value of the '<em><b>Fsm State Machine Initialize Model Sequence</b></em>' reference list.
 	 * The list contents are of type {@link fsmTrace.Steps.Fsm_StateMachine_InitializeModel}.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Fsm State Machine Initialize Model Sequence</em>' reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Fsm State Machine Initialize Model Sequence</em>' reference list.
 	 * @see fsmTrace.FsmTracePackage#getSpecificTrace_Fsm_StateMachine_InitializeModel_Sequence()
@@ -56,10 +52,6 @@ public interface SpecificTrace extends Trace<SequentialStep<? extends SpecificSt
 	 * Returns the value of the '<em><b>Fsm State Step Sequence</b></em>' reference list.
 	 * The list contents are of type {@link fsmTrace.Steps.Fsm_State_Step}.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Fsm State Step Sequence</em>' reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Fsm State Step Sequence</em>' reference list.
 	 * @see fsmTrace.FsmTracePackage#getSpecificTrace_Fsm_State_Step_Sequence()
@@ -72,10 +64,6 @@ public interface SpecificTrace extends Trace<SequentialStep<? extends SpecificSt
 	 * Returns the value of the '<em><b>Fsm Transition Fire Sequence</b></em>' reference list.
 	 * The list contents are of type {@link fsmTrace.Steps.Fsm_Transition_Fire}.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Fsm Transition Fire Sequence</em>' reference list isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Fsm Transition Fire Sequence</em>' reference list.
 	 * @see fsmTrace.FsmTracePackage#getSpecificTrace_Fsm_Transition_Fire_Sequence()

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/StateMachine_consummedString_Value.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/StateMachine_consummedString_Value.java
@@ -23,15 +23,12 @@ public interface StateMachine_consummedString_Value extends SpecificAttributeVal
 	/**
 	 * Returns the value of the '<em><b>Consummed String</b></em>' attribute.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Consummed String</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Consummed String</em>' attribute.
 	 * @see #setConsummedString(String)
 	 * @see fsmTrace.States.StatesPackage#getStateMachine_consummedString_Value_ConsummedString()
 	 * @model unique="false"
+	 *        annotation="aspect"
 	 * @generated
 	 */
 	String getConsummedString();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/StateMachine_currentState_Value.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/StateMachine_currentState_Value.java
@@ -24,15 +24,11 @@ public interface StateMachine_currentState_Value extends SpecificReferenceValue<
 	/**
 	 * Returns the value of the '<em><b>Current State</b></em>' reference.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Current State</em>' reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Current State</em>' reference.
 	 * @see #setCurrentState(TracedState)
 	 * @see fsmTrace.States.StatesPackage#getStateMachine_currentState_Value_CurrentState()
-	 * @model
+	 * @model annotation="aspect"
 	 * @generated
 	 */
 	TracedState getCurrentState();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/StateMachine_producedString_Value.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/StateMachine_producedString_Value.java
@@ -23,15 +23,12 @@ public interface StateMachine_producedString_Value extends SpecificAttributeValu
 	/**
 	 * Returns the value of the '<em><b>Produced String</b></em>' attribute.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Produced String</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Produced String</em>' attribute.
 	 * @see #setProducedString(String)
 	 * @see fsmTrace.States.StatesPackage#getStateMachine_producedString_Value_ProducedString()
 	 * @model unique="false"
+	 *        annotation="aspect"
 	 * @generated
 	 */
 	String getProducedString();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/StateMachine_unprocessedString_Value.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/StateMachine_unprocessedString_Value.java
@@ -23,15 +23,12 @@ public interface StateMachine_unprocessedString_Value extends SpecificAttributeV
 	/**
 	 * Returns the value of the '<em><b>Unprocessed String</b></em>' attribute.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Unprocessed String</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Unprocessed String</em>' attribute.
 	 * @see #setUnprocessedString(String)
 	 * @see fsmTrace.States.StatesPackage#getStateMachine_unprocessedString_Value_UnprocessedString()
 	 * @model unique="false"
+	 *        annotation="aspect"
 	 * @generated
 	 */
 	String getUnprocessedString();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/TracedNamedElement.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/TracedNamedElement.java
@@ -22,7 +22,6 @@ public interface TracedNamedElement extends SpecificTracedObject<SpecificDimensi
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @model kind="operation"
-	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='final EList&lt;SpecificDimension&lt;?&gt;&gt; result = new org.eclipse.emf.ecore.util.BasicInternalEList&lt;SpecificDimension&lt;?&gt;&gt;(Object.class);\nresult.addAll(super.getDimensionsInternal());\nreturn result;\n'"
 	 * @generated
 	 */
 	EList<SpecificDimension<?>> getDimensionsInternal();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/TracedState.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/TracedState.java
@@ -28,10 +28,6 @@ public interface TracedState extends TracedNamedElement {
 	/**
 	 * Returns the value of the '<em><b>Original Object</b></em>' reference.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Original Object</em>' reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Original Object</em>' reference.
 	 * @see #setOriginalObject(State)
@@ -55,7 +51,6 @@ public interface TracedState extends TracedNamedElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @model kind="operation"
-	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='final EList&lt;SpecificDimension&lt;?&gt;&gt; result = new org.eclipse.emf.ecore.util.BasicInternalEList&lt;SpecificDimension&lt;?&gt;&gt;(Object.class);\nresult.addAll(super.getDimensionsInternal());\nreturn result;\n'"
 	 * @generated
 	 */
 	EList<SpecificDimension<?>> getDimensionsInternal();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/TracedStateMachine.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/TracedStateMachine.java
@@ -36,10 +36,6 @@ public interface TracedStateMachine extends TracedNamedElement {
 	/**
 	 * Returns the value of the '<em><b>Original Object</b></em>' reference.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Original Object</em>' reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Original Object</em>' reference.
 	 * @see #setOriginalObject(StateMachine)
@@ -62,10 +58,6 @@ public interface TracedStateMachine extends TracedNamedElement {
 	/**
 	 * Returns the value of the '<em><b>State Machine consummed String Dimension</b></em>' containment reference.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>State Machine consummed String Dimension</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>State Machine consummed String Dimension</em>' containment reference.
 	 * @see #setStateMachine_consummedString_Dimension(StateMachine_consummedString_Dimension)
@@ -88,10 +80,6 @@ public interface TracedStateMachine extends TracedNamedElement {
 	/**
 	 * Returns the value of the '<em><b>State Machine current State Dimension</b></em>' containment reference.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>State Machine current State Dimension</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>State Machine current State Dimension</em>' containment reference.
 	 * @see #setStateMachine_currentState_Dimension(StateMachine_currentState_Dimension)
@@ -114,10 +102,6 @@ public interface TracedStateMachine extends TracedNamedElement {
 	/**
 	 * Returns the value of the '<em><b>State Machine produced String Dimension</b></em>' containment reference.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>State Machine produced String Dimension</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>State Machine produced String Dimension</em>' containment reference.
 	 * @see #setStateMachine_producedString_Dimension(StateMachine_producedString_Dimension)
@@ -140,10 +124,6 @@ public interface TracedStateMachine extends TracedNamedElement {
 	/**
 	 * Returns the value of the '<em><b>State Machine unprocessed String Dimension</b></em>' containment reference.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>State Machine unprocessed String Dimension</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>State Machine unprocessed String Dimension</em>' containment reference.
 	 * @see #setStateMachine_unprocessedString_Dimension(StateMachine_unprocessedString_Dimension)
@@ -167,7 +147,6 @@ public interface TracedStateMachine extends TracedNamedElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @model kind="operation"
-	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='final EList&lt;SpecificDimension&lt;?&gt;&gt; result = new org.eclipse.emf.ecore.util.BasicInternalEList&lt;SpecificDimension&lt;?&gt;&gt;(Object.class);\nresult.addAll(super.getDimensionsInternal());\nresult.add(getStateMachine_unprocessedString_Dimension());\nresult.add(getStateMachine_consummedString_Dimension());\nresult.add(getStateMachine_currentState_Dimension());\nresult.add(getStateMachine_producedString_Dimension());\nreturn result;\n'"
 	 * @generated
 	 */
 	EList<SpecificDimension<?>> getDimensionsInternal();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/TracedTransition.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/TracedTransition.java
@@ -28,10 +28,6 @@ public interface TracedTransition extends TracedNamedElement {
 	/**
 	 * Returns the value of the '<em><b>Original Object</b></em>' reference.
 	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Original Object</em>' reference isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Original Object</em>' reference.
 	 * @see #setOriginalObject(Transition)
@@ -55,7 +51,6 @@ public interface TracedTransition extends TracedNamedElement {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @model kind="operation"
-	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='final EList&lt;SpecificDimension&lt;?&gt;&gt; result = new org.eclipse.emf.ecore.util.BasicInternalEList&lt;SpecificDimension&lt;?&gt;&gt;(Object.class);\nresult.addAll(super.getDimensionsInternal());\nreturn result;\n'"
 	 * @generated
 	 */
 	EList<SpecificDimension<?>> getDimensionsInternal();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/FsmFactoryImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/FsmFactoryImpl.java
@@ -69,6 +69,7 @@ public class FsmFactoryImpl extends EFactoryImpl implements FsmFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public TracedState createTracedState() {
 		TracedStateImpl tracedState = new TracedStateImpl();
 		return tracedState;
@@ -79,6 +80,7 @@ public class FsmFactoryImpl extends EFactoryImpl implements FsmFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public TracedStateMachine createTracedStateMachine() {
 		TracedStateMachineImpl tracedStateMachine = new TracedStateMachineImpl();
 		return tracedStateMachine;
@@ -89,6 +91,7 @@ public class FsmFactoryImpl extends EFactoryImpl implements FsmFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public TracedTransition createTracedTransition() {
 		TracedTransitionImpl tracedTransition = new TracedTransitionImpl();
 		return tracedTransition;
@@ -99,6 +102,7 @@ public class FsmFactoryImpl extends EFactoryImpl implements FsmFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public FsmPackage getFsmPackage() {
 		return (FsmPackage)getEPackage();
 	}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/FsmPackageImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/FsmPackageImpl.java
@@ -87,7 +87,6 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	private FsmPackageImpl() {
 		super(eNS_URI, FsmFactory.eINSTANCE);
 	}
-
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -155,6 +154,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getTracedNamedElement() {
 		return tracedNamedElementEClass;
 	}
@@ -164,6 +164,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getTracedState() {
 		return tracedStateEClass;
 	}
@@ -173,6 +174,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getTracedState_OriginalObject() {
 		return (EReference)tracedStateEClass.getEStructuralFeatures().get(0);
 	}
@@ -182,6 +184,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getTracedStateMachine() {
 		return tracedStateMachineEClass;
 	}
@@ -191,6 +194,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getTracedStateMachine_OriginalObject() {
 		return (EReference)tracedStateMachineEClass.getEStructuralFeatures().get(0);
 	}
@@ -200,6 +204,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getTracedStateMachine_StateMachine_consummedString_Dimension() {
 		return (EReference)tracedStateMachineEClass.getEStructuralFeatures().get(1);
 	}
@@ -209,6 +214,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getTracedStateMachine_StateMachine_currentState_Dimension() {
 		return (EReference)tracedStateMachineEClass.getEStructuralFeatures().get(2);
 	}
@@ -218,6 +224,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getTracedStateMachine_StateMachine_producedString_Dimension() {
 		return (EReference)tracedStateMachineEClass.getEStructuralFeatures().get(3);
 	}
@@ -227,6 +234,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getTracedStateMachine_StateMachine_unprocessedString_Dimension() {
 		return (EReference)tracedStateMachineEClass.getEStructuralFeatures().get(4);
 	}
@@ -236,6 +244,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getTracedTransition() {
 		return tracedTransitionEClass;
 	}
@@ -245,6 +254,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getTracedTransition_OriginalObject() {
 		return (EReference)tracedTransitionEClass.getEStructuralFeatures().get(0);
 	}
@@ -254,6 +264,7 @@ public class FsmPackageImpl extends EPackageImpl implements FsmPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public FsmFactory getFsmFactory() {
 		return (FsmFactory)getEFactoryInstance();
 	}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/TracedNamedElementImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/TracedNamedElementImpl.java
@@ -45,6 +45,7 @@ public abstract class TracedNamedElementImpl extends SpecificTracedObjectImpl<Sp
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<SpecificDimension<?>> getDimensionsInternal() {
 		final EList<SpecificDimension<?>> result = new org.eclipse.emf.ecore.util.BasicInternalEList<SpecificDimension<?>>(Object.class);
 		result.addAll(super.getDimensionsInternal());

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/TracedStateImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/TracedStateImpl.java
@@ -66,6 +66,7 @@ public class TracedStateImpl extends TracedNamedElementImpl implements TracedSta
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public State getOriginalObject() {
 		if (originalObject != null && originalObject.eIsProxy()) {
 			InternalEObject oldOriginalObject = (InternalEObject)originalObject;
@@ -92,6 +93,7 @@ public class TracedStateImpl extends TracedNamedElementImpl implements TracedSta
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setOriginalObject(State newOriginalObject) {
 		State oldOriginalObject = originalObject;
 		originalObject = newOriginalObject;
@@ -104,6 +106,7 @@ public class TracedStateImpl extends TracedNamedElementImpl implements TracedSta
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<SpecificDimension<?>> getDimensionsInternal() {
 		final EList<SpecificDimension<?>> result = new org.eclipse.emf.ecore.util.BasicInternalEList<SpecificDimension<?>>(Object.class);
 		result.addAll(super.getDimensionsInternal());

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/TracedStateMachineImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/TracedStateMachineImpl.java
@@ -115,6 +115,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine getOriginalObject() {
 		if (originalObject != null && originalObject.eIsProxy()) {
 			InternalEObject oldOriginalObject = (InternalEObject)originalObject;
@@ -141,6 +142,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setOriginalObject(StateMachine newOriginalObject) {
 		StateMachine oldOriginalObject = originalObject;
 		originalObject = newOriginalObject;
@@ -153,6 +155,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_consummedString_Dimension getStateMachine_consummedString_Dimension() {
 		return stateMachine_consummedString_Dimension;
 	}
@@ -177,6 +180,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setStateMachine_consummedString_Dimension(StateMachine_consummedString_Dimension newStateMachine_consummedString_Dimension) {
 		if (newStateMachine_consummedString_Dimension != stateMachine_consummedString_Dimension) {
 			NotificationChain msgs = null;
@@ -196,6 +200,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_currentState_Dimension getStateMachine_currentState_Dimension() {
 		return stateMachine_currentState_Dimension;
 	}
@@ -220,6 +225,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setStateMachine_currentState_Dimension(StateMachine_currentState_Dimension newStateMachine_currentState_Dimension) {
 		if (newStateMachine_currentState_Dimension != stateMachine_currentState_Dimension) {
 			NotificationChain msgs = null;
@@ -239,6 +245,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_producedString_Dimension getStateMachine_producedString_Dimension() {
 		return stateMachine_producedString_Dimension;
 	}
@@ -263,6 +270,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setStateMachine_producedString_Dimension(StateMachine_producedString_Dimension newStateMachine_producedString_Dimension) {
 		if (newStateMachine_producedString_Dimension != stateMachine_producedString_Dimension) {
 			NotificationChain msgs = null;
@@ -282,6 +290,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_unprocessedString_Dimension getStateMachine_unprocessedString_Dimension() {
 		return stateMachine_unprocessedString_Dimension;
 	}
@@ -306,6 +315,7 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setStateMachine_unprocessedString_Dimension(StateMachine_unprocessedString_Dimension newStateMachine_unprocessedString_Dimension) {
 		if (newStateMachine_unprocessedString_Dimension != stateMachine_unprocessedString_Dimension) {
 			NotificationChain msgs = null;
@@ -325,13 +335,14 @@ public class TracedStateMachineImpl extends TracedNamedElementImpl implements Tr
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<SpecificDimension<?>> getDimensionsInternal() {
 		final EList<SpecificDimension<?>> result = new org.eclipse.emf.ecore.util.BasicInternalEList<SpecificDimension<?>>(Object.class);
 		result.addAll(super.getDimensionsInternal());
-		result.add(getStateMachine_unprocessedString_Dimension());
 		result.add(getStateMachine_consummedString_Dimension());
-		result.add(getStateMachine_currentState_Dimension());
 		result.add(getStateMachine_producedString_Dimension());
+		result.add(getStateMachine_currentState_Dimension());
+		result.add(getStateMachine_unprocessedString_Dimension());
 		return result;
 		
 	}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/TracedTransitionImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/fsm/impl/TracedTransitionImpl.java
@@ -66,6 +66,7 @@ public class TracedTransitionImpl extends TracedNamedElementImpl implements Trac
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Transition getOriginalObject() {
 		if (originalObject != null && originalObject.eIsProxy()) {
 			InternalEObject oldOriginalObject = (InternalEObject)originalObject;
@@ -92,6 +93,7 @@ public class TracedTransitionImpl extends TracedNamedElementImpl implements Trac
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setOriginalObject(Transition newOriginalObject) {
 		Transition oldOriginalObject = originalObject;
 		originalObject = newOriginalObject;
@@ -104,6 +106,7 @@ public class TracedTransitionImpl extends TracedNamedElementImpl implements Trac
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<SpecificDimension<?>> getDimensionsInternal() {
 		final EList<SpecificDimension<?>> result = new org.eclipse.emf.ecore.util.BasicInternalEList<SpecificDimension<?>>(Object.class);
 		result.addAll(super.getDimensionsInternal());

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StateMachine_consummedString_ValueImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StateMachine_consummedString_ValueImpl.java
@@ -69,6 +69,7 @@ public class StateMachine_consummedString_ValueImpl extends SpecificValueImpl im
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getConsummedString() {
 		return consummedString;
 	}
@@ -78,6 +79,7 @@ public class StateMachine_consummedString_ValueImpl extends SpecificValueImpl im
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setConsummedString(String newConsummedString) {
 		String oldConsummedString = consummedString;
 		consummedString = newConsummedString;

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StateMachine_currentState_ValueImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StateMachine_currentState_ValueImpl.java
@@ -62,6 +62,7 @@ public class StateMachine_currentState_ValueImpl extends SpecificValueImpl imple
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public TracedState getCurrentState() {
 		if (currentState != null && currentState.eIsProxy()) {
 			InternalEObject oldCurrentState = (InternalEObject)currentState;
@@ -88,6 +89,7 @@ public class StateMachine_currentState_ValueImpl extends SpecificValueImpl imple
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setCurrentState(TracedState newCurrentState) {
 		TracedState oldCurrentState = currentState;
 		currentState = newCurrentState;

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StateMachine_producedString_ValueImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StateMachine_producedString_ValueImpl.java
@@ -69,6 +69,7 @@ public class StateMachine_producedString_ValueImpl extends SpecificValueImpl imp
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getProducedString() {
 		return producedString;
 	}
@@ -78,6 +79,7 @@ public class StateMachine_producedString_ValueImpl extends SpecificValueImpl imp
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setProducedString(String newProducedString) {
 		String oldProducedString = producedString;
 		producedString = newProducedString;

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StateMachine_unprocessedString_ValueImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StateMachine_unprocessedString_ValueImpl.java
@@ -69,6 +69,7 @@ public class StateMachine_unprocessedString_ValueImpl extends SpecificValueImpl 
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public String getUnprocessedString() {
 		return unprocessedString;
 	}
@@ -78,6 +79,7 @@ public class StateMachine_unprocessedString_ValueImpl extends SpecificValueImpl 
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public void setUnprocessedString(String newUnprocessedString) {
 		String oldUnprocessedString = unprocessedString;
 		unprocessedString = newUnprocessedString;

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StatesFactoryImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StatesFactoryImpl.java
@@ -75,6 +75,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public SpecificState createSpecificState() {
 		SpecificStateImpl specificState = new SpecificStateImpl();
 		return specificState;
@@ -85,6 +86,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_consummedString_Dimension createStateMachine_consummedString_Dimension() {
 		StateMachine_consummedString_DimensionImpl stateMachine_consummedString_Dimension = new StateMachine_consummedString_DimensionImpl();
 		return stateMachine_consummedString_Dimension;
@@ -95,6 +97,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_consummedString_Value createStateMachine_consummedString_Value() {
 		StateMachine_consummedString_ValueImpl stateMachine_consummedString_Value = new StateMachine_consummedString_ValueImpl();
 		return stateMachine_consummedString_Value;
@@ -105,6 +108,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_currentState_Dimension createStateMachine_currentState_Dimension() {
 		StateMachine_currentState_DimensionImpl stateMachine_currentState_Dimension = new StateMachine_currentState_DimensionImpl();
 		return stateMachine_currentState_Dimension;
@@ -115,6 +119,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_currentState_Value createStateMachine_currentState_Value() {
 		StateMachine_currentState_ValueImpl stateMachine_currentState_Value = new StateMachine_currentState_ValueImpl();
 		return stateMachine_currentState_Value;
@@ -125,6 +130,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_producedString_Dimension createStateMachine_producedString_Dimension() {
 		StateMachine_producedString_DimensionImpl stateMachine_producedString_Dimension = new StateMachine_producedString_DimensionImpl();
 		return stateMachine_producedString_Dimension;
@@ -135,6 +141,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_producedString_Value createStateMachine_producedString_Value() {
 		StateMachine_producedString_ValueImpl stateMachine_producedString_Value = new StateMachine_producedString_ValueImpl();
 		return stateMachine_producedString_Value;
@@ -145,6 +152,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_unprocessedString_Dimension createStateMachine_unprocessedString_Dimension() {
 		StateMachine_unprocessedString_DimensionImpl stateMachine_unprocessedString_Dimension = new StateMachine_unprocessedString_DimensionImpl();
 		return stateMachine_unprocessedString_Dimension;
@@ -155,6 +163,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StateMachine_unprocessedString_Value createStateMachine_unprocessedString_Value() {
 		StateMachine_unprocessedString_ValueImpl stateMachine_unprocessedString_Value = new StateMachine_unprocessedString_ValueImpl();
 		return stateMachine_unprocessedString_Value;
@@ -165,6 +174,7 @@ public class StatesFactoryImpl extends EFactoryImpl implements StatesFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StatesPackage getStatesPackage() {
 		return (StatesPackage)getEPackage();
 	}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StatesPackageImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/States/impl/StatesPackageImpl.java
@@ -168,7 +168,6 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	private StatesPackageImpl() {
 		super(eNS_URI, StatesFactory.eINSTANCE);
 	}
-
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -236,6 +235,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSpecificAttributeValue() {
 		return specificAttributeValueEClass;
 	}
@@ -245,6 +245,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSpecificDimension() {
 		return specificDimensionEClass;
 	}
@@ -254,6 +255,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSpecificReferenceValue() {
 		return specificReferenceValueEClass;
 	}
@@ -263,6 +265,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSpecificState() {
 		return specificStateEClass;
 	}
@@ -272,6 +275,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSpecificTracedObject() {
 		return specificTracedObjectEClass;
 	}
@@ -281,6 +285,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSpecificValue() {
 		return specificValueEClass;
 	}
@@ -290,6 +295,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getStateMachine_consummedString_Dimension() {
 		return stateMachine_consummedString_DimensionEClass;
 	}
@@ -299,6 +305,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getStateMachine_consummedString_Value() {
 		return stateMachine_consummedString_ValueEClass;
 	}
@@ -308,6 +315,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getStateMachine_consummedString_Value_ConsummedString() {
 		return (EAttribute)stateMachine_consummedString_ValueEClass.getEStructuralFeatures().get(0);
 	}
@@ -317,6 +325,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getStateMachine_currentState_Dimension() {
 		return stateMachine_currentState_DimensionEClass;
 	}
@@ -326,6 +335,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getStateMachine_currentState_Value() {
 		return stateMachine_currentState_ValueEClass;
 	}
@@ -335,6 +345,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getStateMachine_currentState_Value_CurrentState() {
 		return (EReference)stateMachine_currentState_ValueEClass.getEStructuralFeatures().get(0);
 	}
@@ -344,6 +355,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getStateMachine_producedString_Dimension() {
 		return stateMachine_producedString_DimensionEClass;
 	}
@@ -353,6 +365,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getStateMachine_producedString_Value() {
 		return stateMachine_producedString_ValueEClass;
 	}
@@ -362,6 +375,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getStateMachine_producedString_Value_ProducedString() {
 		return (EAttribute)stateMachine_producedString_ValueEClass.getEStructuralFeatures().get(0);
 	}
@@ -371,6 +385,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getStateMachine_unprocessedString_Dimension() {
 		return stateMachine_unprocessedString_DimensionEClass;
 	}
@@ -380,6 +395,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getStateMachine_unprocessedString_Value() {
 		return stateMachine_unprocessedString_ValueEClass;
 	}
@@ -389,6 +405,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EAttribute getStateMachine_unprocessedString_Value_UnprocessedString() {
 		return (EAttribute)stateMachine_unprocessedString_ValueEClass.getEStructuralFeatures().get(0);
 	}
@@ -398,6 +415,7 @@ public class StatesPackageImpl extends EPackageImpl implements StatesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StatesFactory getStatesFactory() {
 		return (StatesFactory)getEFactoryInstance();
 	}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/Fsm_StateMachine_InitializeModel.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/Fsm_StateMachine_InitializeModel.java
@@ -23,7 +23,6 @@ public interface Fsm_StateMachine_InitializeModel extends SpecificStep, SmallSte
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @model kind="operation" required="true"
-	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='return (fsmTrace.States.fsm.TracedStateMachine) this.getMseoccurrence().getMse().getCaller();'"
 	 * @generated
 	 */
 	TracedStateMachine getCaller();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/Fsm_State_Step.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/Fsm_State_Step.java
@@ -23,7 +23,6 @@ public interface Fsm_State_Step extends SpecificStep, SequentialStep<Fsm_State_S
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @model kind="operation" required="true"
-	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='return (fsmTrace.States.fsm.TracedState) this.getMseoccurrence().getMse().getCaller();'"
 	 * @generated
 	 */
 	TracedState getCaller();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/Fsm_Transition_Fire.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/Fsm_Transition_Fire.java
@@ -18,12 +18,11 @@ import org.eclipse.gemoc.trace.commons.model.trace.SmallStep;
  * @model
  * @generated
  */
-public interface Fsm_Transition_Fire extends SpecificStep, SmallStep<SpecificState>, Fsm_State_Step_AbstractSubStep {
+public interface Fsm_Transition_Fire extends Fsm_State_Step_AbstractSubStep, SpecificStep, SmallStep<SpecificState> {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @model kind="operation" required="true"
-	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='return (fsmTrace.States.fsm.TracedTransition) this.getMseoccurrence().getMse().getCaller();'"
 	 * @generated
 	 */
 	TracedTransition getCaller();

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/StepsPackage.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/StepsPackage.java
@@ -139,13 +139,22 @@ public interface StepsPackage extends EPackage {
 	int FSM_STATE_MACHINE_INITIALIZE_MODEL__ENDING_STATE = SPECIFIC_STEP__ENDING_STATE;
 
 	/**
+	 * The feature id for the '<em><b>Footprint</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT = SPECIFIC_STEP_FEATURE_COUNT + 0;
+
+	/**
 	 * The number of structural features of the '<em>Fsm State Machine Initialize Model</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int FSM_STATE_MACHINE_INITIALIZE_MODEL_FEATURE_COUNT = SPECIFIC_STEP_FEATURE_COUNT + 0;
+	int FSM_STATE_MACHINE_INITIALIZE_MODEL_FEATURE_COUNT = SPECIFIC_STEP_FEATURE_COUNT + 1;
 
 	/**
 	 * The meta object id for the '{@link fsmTrace.Steps.impl.Fsm_State_StepImpl <em>Fsm State Step</em>}' class.
@@ -286,13 +295,22 @@ public interface StepsPackage extends EPackage {
 	int FSM_STATE_STEP_IMPLICIT_STEP__ENDING_STATE = FSM_STATE_STEP_ABSTRACT_SUB_STEP__ENDING_STATE;
 
 	/**
+	 * The feature id for the '<em><b>Footprint</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT = FSM_STATE_STEP_ABSTRACT_SUB_STEP_FEATURE_COUNT + 0;
+
+	/**
 	 * The number of structural features of the '<em>Fsm State Step Implicit Step</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int FSM_STATE_STEP_IMPLICIT_STEP_FEATURE_COUNT = FSM_STATE_STEP_ABSTRACT_SUB_STEP_FEATURE_COUNT + 0;
+	int FSM_STATE_STEP_IMPLICIT_STEP_FEATURE_COUNT = FSM_STATE_STEP_ABSTRACT_SUB_STEP_FEATURE_COUNT + 1;
 
 	/**
 	 * The meta object id for the '{@link fsmTrace.Steps.impl.Fsm_Transition_FireImpl <em>Fsm Transition Fire</em>}' class.
@@ -311,7 +329,7 @@ public interface StepsPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int FSM_TRANSITION_FIRE__MSEOCCURRENCE = SPECIFIC_STEP__MSEOCCURRENCE;
+	int FSM_TRANSITION_FIRE__MSEOCCURRENCE = FSM_STATE_STEP_ABSTRACT_SUB_STEP__MSEOCCURRENCE;
 
 	/**
 	 * The feature id for the '<em><b>Starting State</b></em>' reference.
@@ -320,7 +338,7 @@ public interface StepsPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int FSM_TRANSITION_FIRE__STARTING_STATE = SPECIFIC_STEP__STARTING_STATE;
+	int FSM_TRANSITION_FIRE__STARTING_STATE = FSM_STATE_STEP_ABSTRACT_SUB_STEP__STARTING_STATE;
 
 	/**
 	 * The feature id for the '<em><b>Ending State</b></em>' reference.
@@ -329,7 +347,16 @@ public interface StepsPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int FSM_TRANSITION_FIRE__ENDING_STATE = SPECIFIC_STEP__ENDING_STATE;
+	int FSM_TRANSITION_FIRE__ENDING_STATE = FSM_STATE_STEP_ABSTRACT_SUB_STEP__ENDING_STATE;
+
+	/**
+	 * The feature id for the '<em><b>Footprint</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int FSM_TRANSITION_FIRE__FOOTPRINT = FSM_STATE_STEP_ABSTRACT_SUB_STEP_FEATURE_COUNT + 0;
 
 	/**
 	 * The number of structural features of the '<em>Fsm Transition Fire</em>' class.
@@ -338,7 +365,7 @@ public interface StepsPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int FSM_TRANSITION_FIRE_FEATURE_COUNT = SPECIFIC_STEP_FEATURE_COUNT + 0;
+	int FSM_TRANSITION_FIRE_FEATURE_COUNT = FSM_STATE_STEP_ABSTRACT_SUB_STEP_FEATURE_COUNT + 1;
 
 	/**
 	 * The meta object id for the '{@link fsmTrace.Steps.impl.RootImplicitStepImpl <em>Root Implicit Step</em>}' class.
@@ -376,6 +403,15 @@ public interface StepsPackage extends EPackage {
 	 * @ordered
 	 */
 	int ROOT_IMPLICIT_STEP__ENDING_STATE = TracePackage.SMALL_STEP__ENDING_STATE;
+
+	/**
+	 * The feature id for the '<em><b>Footprint</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ROOT_IMPLICIT_STEP__FOOTPRINT = TracePackage.SMALL_STEP__FOOTPRINT;
 
 	/**
 	 * The number of structural features of the '<em>Root Implicit Step</em>' class.

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/Fsm_StateMachine_InitializeModelImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/Fsm_StateMachine_InitializeModelImpl.java
@@ -7,16 +7,42 @@ import fsmTrace.States.fsm.TracedStateMachine;
 import fsmTrace.Steps.Fsm_StateMachine_InitializeModel;
 import fsmTrace.Steps.StepsPackage;
 
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.NotificationChain;
+
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+
+import org.eclipse.gemoc.trace.commons.model.trace.Footprint;
+import org.eclipse.gemoc.trace.commons.model.trace.SmallStep;
+import org.eclipse.gemoc.trace.commons.model.trace.TracePackage;
 
 /**
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Fsm State Machine Initialize Model</b></em>'.
  * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link fsmTrace.Steps.impl.Fsm_StateMachine_InitializeModelImpl#getFootprint <em>Footprint</em>}</li>
+ * </ul>
  *
  * @generated
  */
 public class Fsm_StateMachine_InitializeModelImpl extends SpecificStepImpl implements Fsm_StateMachine_InitializeModel {
+	/**
+	 * The cached value of the '{@link #getFootprint() <em>Footprint</em>}' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getFootprint()
+	 * @generated
+	 * @ordered
+	 */
+	protected Footprint footprint;
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -41,8 +67,158 @@ public class Fsm_StateMachine_InitializeModelImpl extends SpecificStepImpl imple
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
+	public Footprint getFootprint() {
+		return footprint;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public NotificationChain basicSetFootprint(Footprint newFootprint, NotificationChain msgs) {
+		Footprint oldFootprint = footprint;
+		footprint = newFootprint;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT, oldFootprint, newFootprint);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setFootprint(Footprint newFootprint) {
+		if (newFootprint != footprint) {
+			NotificationChain msgs = null;
+			if (footprint != null)
+				msgs = ((InternalEObject)footprint).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT, null, msgs);
+			if (newFootprint != null)
+				msgs = ((InternalEObject)newFootprint).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT, null, msgs);
+			msgs = basicSetFootprint(newFootprint, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT, newFootprint, newFootprint));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public TracedStateMachine getCaller() {
 		return (fsmTrace.States.fsm.TracedStateMachine) this.getMseoccurrence().getMse().getCaller();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT:
+				return basicSetFootprint(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT:
+				return getFootprint();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT:
+				setFootprint((Footprint)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT:
+				setFootprint((Footprint)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT:
+				return footprint != null;
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
+		if (baseClass == SmallStep.class) {
+			switch (derivedFeatureID) {
+				case StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT: return TracePackage.SMALL_STEP__FOOTPRINT;
+				default: return -1;
+			}
+		}
+		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
+		if (baseClass == SmallStep.class) {
+			switch (baseFeatureID) {
+				case TracePackage.SMALL_STEP__FOOTPRINT: return StepsPackage.FSM_STATE_MACHINE_INITIALIZE_MODEL__FOOTPRINT;
+				default: return -1;
+			}
+		}
+		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
 	}
 
 } //Fsm_StateMachine_InitializeModelImpl

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/Fsm_State_StepImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/Fsm_State_StepImpl.java
@@ -72,6 +72,7 @@ public class Fsm_State_StepImpl extends SpecificStepImpl implements Fsm_State_St
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Fsm_State_Step_AbstractSubStep> getSubSteps() {
 		if (subSteps == null) {
 			subSteps = new EObjectContainmentEList<Fsm_State_Step_AbstractSubStep>(Fsm_State_Step_AbstractSubStep.class, this, StepsPackage.FSM_STATE_STEP__SUB_STEPS);
@@ -84,6 +85,7 @@ public class Fsm_State_StepImpl extends SpecificStepImpl implements Fsm_State_St
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public TracedState getCaller() {
 		return (fsmTrace.States.fsm.TracedState) this.getMseoccurrence().getMse().getCaller();
 	}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/Fsm_State_Step_ImplicitStepImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/Fsm_State_Step_ImplicitStepImpl.java
@@ -5,16 +5,42 @@ package fsmTrace.Steps.impl;
 import fsmTrace.Steps.Fsm_State_Step_ImplicitStep;
 import fsmTrace.Steps.StepsPackage;
 
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.NotificationChain;
+
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+
+import org.eclipse.gemoc.trace.commons.model.trace.Footprint;
+import org.eclipse.gemoc.trace.commons.model.trace.SmallStep;
+import org.eclipse.gemoc.trace.commons.model.trace.TracePackage;
 
 /**
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Fsm State Step Implicit Step</b></em>'.
  * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link fsmTrace.Steps.impl.Fsm_State_Step_ImplicitStepImpl#getFootprint <em>Footprint</em>}</li>
+ * </ul>
  *
  * @generated
  */
 public class Fsm_State_Step_ImplicitStepImpl extends SpecificStepImpl implements Fsm_State_Step_ImplicitStep {
+	/**
+	 * The cached value of the '{@link #getFootprint() <em>Footprint</em>}' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getFootprint()
+	 * @generated
+	 * @ordered
+	 */
+	protected Footprint footprint;
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -32,6 +58,155 @@ public class Fsm_State_Step_ImplicitStepImpl extends SpecificStepImpl implements
 	@Override
 	protected EClass eStaticClass() {
 		return StepsPackage.Literals.FSM_STATE_STEP_IMPLICIT_STEP;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Footprint getFootprint() {
+		return footprint;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public NotificationChain basicSetFootprint(Footprint newFootprint, NotificationChain msgs) {
+		Footprint oldFootprint = footprint;
+		footprint = newFootprint;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT, oldFootprint, newFootprint);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setFootprint(Footprint newFootprint) {
+		if (newFootprint != footprint) {
+			NotificationChain msgs = null;
+			if (footprint != null)
+				msgs = ((InternalEObject)footprint).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT, null, msgs);
+			if (newFootprint != null)
+				msgs = ((InternalEObject)newFootprint).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT, null, msgs);
+			msgs = basicSetFootprint(newFootprint, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT, newFootprint, newFootprint));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT:
+				return basicSetFootprint(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT:
+				return getFootprint();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT:
+				setFootprint((Footprint)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT:
+				setFootprint((Footprint)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT:
+				return footprint != null;
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
+		if (baseClass == SmallStep.class) {
+			switch (derivedFeatureID) {
+				case StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT: return TracePackage.SMALL_STEP__FOOTPRINT;
+				default: return -1;
+			}
+		}
+		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
+		if (baseClass == SmallStep.class) {
+			switch (baseFeatureID) {
+				case TracePackage.SMALL_STEP__FOOTPRINT: return StepsPackage.FSM_STATE_STEP_IMPLICIT_STEP__FOOTPRINT;
+				default: return -1;
+			}
+		}
+		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
 	}
 
 } //Fsm_State_Step_ImplicitStepImpl

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/Fsm_Transition_FireImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/Fsm_Transition_FireImpl.java
@@ -7,16 +7,42 @@ import fsmTrace.States.fsm.TracedTransition;
 import fsmTrace.Steps.Fsm_Transition_Fire;
 import fsmTrace.Steps.StepsPackage;
 
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.NotificationChain;
+
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+
+import org.eclipse.gemoc.trace.commons.model.trace.Footprint;
+import org.eclipse.gemoc.trace.commons.model.trace.SmallStep;
+import org.eclipse.gemoc.trace.commons.model.trace.TracePackage;
 
 /**
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Fsm Transition Fire</b></em>'.
  * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * </p>
+ * <ul>
+ *   <li>{@link fsmTrace.Steps.impl.Fsm_Transition_FireImpl#getFootprint <em>Footprint</em>}</li>
+ * </ul>
  *
  * @generated
  */
 public class Fsm_Transition_FireImpl extends SpecificStepImpl implements Fsm_Transition_Fire {
+	/**
+	 * The cached value of the '{@link #getFootprint() <em>Footprint</em>}' containment reference.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getFootprint()
+	 * @generated
+	 * @ordered
+	 */
+	protected Footprint footprint;
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -41,8 +67,158 @@ public class Fsm_Transition_FireImpl extends SpecificStepImpl implements Fsm_Tra
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
+	public Footprint getFootprint() {
+		return footprint;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public NotificationChain basicSetFootprint(Footprint newFootprint, NotificationChain msgs) {
+		Footprint oldFootprint = footprint;
+		footprint = newFootprint;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT, oldFootprint, newFootprint);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void setFootprint(Footprint newFootprint) {
+		if (newFootprint != footprint) {
+			NotificationChain msgs = null;
+			if (footprint != null)
+				msgs = ((InternalEObject)footprint).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT, null, msgs);
+			if (newFootprint != null)
+				msgs = ((InternalEObject)newFootprint).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT, null, msgs);
+			msgs = basicSetFootprint(newFootprint, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT, newFootprint, newFootprint));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public TracedTransition getCaller() {
 		return (fsmTrace.States.fsm.TracedTransition) this.getMseoccurrence().getMse().getCaller();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+		switch (featureID) {
+			case StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT:
+				return basicSetFootprint(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Object eGet(int featureID, boolean resolve, boolean coreType) {
+		switch (featureID) {
+			case StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT:
+				return getFootprint();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eSet(int featureID, Object newValue) {
+		switch (featureID) {
+			case StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT:
+				setFootprint((Footprint)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public void eUnset(int featureID) {
+		switch (featureID) {
+			case StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT:
+				setFootprint((Footprint)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public boolean eIsSet(int featureID) {
+		switch (featureID) {
+			case StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT:
+				return footprint != null;
+		}
+		return super.eIsSet(featureID);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
+		if (baseClass == SmallStep.class) {
+			switch (derivedFeatureID) {
+				case StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT: return TracePackage.SMALL_STEP__FOOTPRINT;
+				default: return -1;
+			}
+		}
+		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
+		if (baseClass == SmallStep.class) {
+			switch (baseFeatureID) {
+				case TracePackage.SMALL_STEP__FOOTPRINT: return StepsPackage.FSM_TRANSITION_FIRE__FOOTPRINT;
+				default: return -1;
+			}
+		}
+		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
 	}
 
 } //Fsm_Transition_FireImpl

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/StepsFactoryImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/StepsFactoryImpl.java
@@ -72,6 +72,7 @@ public class StepsFactoryImpl extends EFactoryImpl implements StepsFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Fsm_StateMachine_InitializeModel createFsm_StateMachine_InitializeModel() {
 		Fsm_StateMachine_InitializeModelImpl fsm_StateMachine_InitializeModel = new Fsm_StateMachine_InitializeModelImpl();
 		return fsm_StateMachine_InitializeModel;
@@ -82,6 +83,7 @@ public class StepsFactoryImpl extends EFactoryImpl implements StepsFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Fsm_State_Step createFsm_State_Step() {
 		Fsm_State_StepImpl fsm_State_Step = new Fsm_State_StepImpl();
 		return fsm_State_Step;
@@ -92,6 +94,7 @@ public class StepsFactoryImpl extends EFactoryImpl implements StepsFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Fsm_State_Step_ImplicitStep createFsm_State_Step_ImplicitStep() {
 		Fsm_State_Step_ImplicitStepImpl fsm_State_Step_ImplicitStep = new Fsm_State_Step_ImplicitStepImpl();
 		return fsm_State_Step_ImplicitStep;
@@ -102,6 +105,7 @@ public class StepsFactoryImpl extends EFactoryImpl implements StepsFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public Fsm_Transition_Fire createFsm_Transition_Fire() {
 		Fsm_Transition_FireImpl fsm_Transition_Fire = new Fsm_Transition_FireImpl();
 		return fsm_Transition_Fire;
@@ -112,6 +116,7 @@ public class StepsFactoryImpl extends EFactoryImpl implements StepsFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public RootImplicitStep createRootImplicitStep() {
 		RootImplicitStepImpl rootImplicitStep = new RootImplicitStepImpl();
 		return rootImplicitStep;
@@ -122,6 +127,7 @@ public class StepsFactoryImpl extends EFactoryImpl implements StepsFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public SpecificRootStep createSpecificRootStep() {
 		SpecificRootStepImpl specificRootStep = new SpecificRootStepImpl();
 		return specificRootStep;
@@ -132,6 +138,7 @@ public class StepsFactoryImpl extends EFactoryImpl implements StepsFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StepsPackage getStepsPackage() {
 		return (StepsPackage)getEPackage();
 	}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/StepsPackageImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/impl/StepsPackageImpl.java
@@ -117,7 +117,6 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	private StepsPackageImpl() {
 		super(eNS_URI, StepsFactory.eINSTANCE);
 	}
-
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -185,6 +184,7 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFsm_StateMachine_InitializeModel() {
 		return fsm_StateMachine_InitializeModelEClass;
 	}
@@ -194,6 +194,7 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFsm_State_Step() {
 		return fsm_State_StepEClass;
 	}
@@ -203,6 +204,7 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFsm_State_Step_AbstractSubStep() {
 		return fsm_State_Step_AbstractSubStepEClass;
 	}
@@ -212,6 +214,7 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFsm_State_Step_ImplicitStep() {
 		return fsm_State_Step_ImplicitStepEClass;
 	}
@@ -221,6 +224,7 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getFsm_Transition_Fire() {
 		return fsm_Transition_FireEClass;
 	}
@@ -230,6 +234,7 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getRootImplicitStep() {
 		return rootImplicitStepEClass;
 	}
@@ -239,6 +244,7 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSpecificRootStep() {
 		return specificRootStepEClass;
 	}
@@ -248,6 +254,7 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSpecificStep() {
 		return specificStepEClass;
 	}
@@ -257,6 +264,7 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public StepsFactory getStepsFactory() {
 		return (StepsFactory)getEFactoryInstance();
 	}
@@ -351,13 +359,13 @@ public class StepsPackageImpl extends EPackageImpl implements StepsPackage {
 		g2 = createEGenericType(theStatesPackage.getSpecificState());
 		g1.getETypeArguments().add(g2);
 		fsm_State_Step_ImplicitStepEClass.getEGenericSuperTypes().add(g1);
+		g1 = createEGenericType(this.getFsm_State_Step_AbstractSubStep());
+		fsm_Transition_FireEClass.getEGenericSuperTypes().add(g1);
 		g1 = createEGenericType(this.getSpecificStep());
 		fsm_Transition_FireEClass.getEGenericSuperTypes().add(g1);
 		g1 = createEGenericType(theTracePackage.getSmallStep());
 		g2 = createEGenericType(theStatesPackage.getSpecificState());
 		g1.getETypeArguments().add(g2);
-		fsm_Transition_FireEClass.getEGenericSuperTypes().add(g1);
-		g1 = createEGenericType(this.getFsm_State_Step_AbstractSubStep());
 		fsm_Transition_FireEClass.getEGenericSuperTypes().add(g1);
 		g1 = createEGenericType(theTracePackage.getSmallStep());
 		g2 = createEGenericType(theStatesPackage.getSpecificState());

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/util/StepsSwitch.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/Steps/util/StepsSwitch.java
@@ -112,8 +112,8 @@ public class StepsSwitch<T> extends Switch<T> {
 			case StepsPackage.FSM_TRANSITION_FIRE: {
 				Fsm_Transition_Fire fsm_Transition_Fire = (Fsm_Transition_Fire)theEObject;
 				T result = caseFsm_Transition_Fire(fsm_Transition_Fire);
-				if (result == null) result = caseSmallStep(fsm_Transition_Fire);
 				if (result == null) result = caseFsm_State_Step_AbstractSubStep(fsm_Transition_Fire);
+				if (result == null) result = caseSmallStep(fsm_Transition_Fire);
 				if (result == null) result = caseSpecificStep(fsm_Transition_Fire);
 				if (result == null) result = caseStep(fsm_Transition_Fire);
 				if (result == null) result = defaultCase(theEObject);

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/impl/FsmTraceFactoryImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/impl/FsmTraceFactoryImpl.java
@@ -67,6 +67,7 @@ public class FsmTraceFactoryImpl extends EFactoryImpl implements FsmTraceFactory
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public SpecificTrace createSpecificTrace() {
 		SpecificTraceImpl specificTrace = new SpecificTraceImpl();
 		return specificTrace;
@@ -77,6 +78,7 @@ public class FsmTraceFactoryImpl extends EFactoryImpl implements FsmTraceFactory
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public FsmTracePackage getFsmTracePackage() {
 		return (FsmTracePackage)getEPackage();
 	}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/impl/FsmTracePackageImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/impl/FsmTracePackageImpl.java
@@ -62,7 +62,6 @@ public class FsmTracePackageImpl extends EPackageImpl implements FsmTracePackage
 	private FsmTracePackageImpl() {
 		super(eNS_URI, FsmTraceFactory.eINSTANCE);
 	}
-
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -130,6 +129,7 @@ public class FsmTracePackageImpl extends EPackageImpl implements FsmTracePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EClass getSpecificTrace() {
 		return specificTraceEClass;
 	}
@@ -139,6 +139,7 @@ public class FsmTracePackageImpl extends EPackageImpl implements FsmTracePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getSpecificTrace_Fsm_StateMachine_InitializeModel_Sequence() {
 		return (EReference)specificTraceEClass.getEStructuralFeatures().get(0);
 	}
@@ -148,6 +149,7 @@ public class FsmTracePackageImpl extends EPackageImpl implements FsmTracePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getSpecificTrace_Fsm_State_Step_Sequence() {
 		return (EReference)specificTraceEClass.getEStructuralFeatures().get(1);
 	}
@@ -157,6 +159,7 @@ public class FsmTracePackageImpl extends EPackageImpl implements FsmTracePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EReference getSpecificTrace_Fsm_Transition_Fire_Sequence() {
 		return (EReference)specificTraceEClass.getEStructuralFeatures().get(2);
 	}
@@ -166,6 +169,7 @@ public class FsmTracePackageImpl extends EPackageImpl implements FsmTracePackage
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public FsmTraceFactory getFsmTraceFactory() {
 		return (FsmTraceFactory)getEFactoryInstance();
 	}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/impl/SpecificTraceImpl.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/fsmTrace/impl/SpecificTraceImpl.java
@@ -139,6 +139,7 @@ public class SpecificTraceImpl extends TraceImpl<SequentialStep<? extends Specif
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Fsm_StateMachine_InitializeModel> getFsm_StateMachine_InitializeModel_Sequence() {
 		if (fsm_StateMachine_InitializeModel_Sequence == null) {
 			fsm_StateMachine_InitializeModel_Sequence = new EObjectResolvingEList<Fsm_StateMachine_InitializeModel>(Fsm_StateMachine_InitializeModel.class, this, FsmTracePackage.SPECIFIC_TRACE__FSM_STATE_MACHINE_INITIALIZE_MODEL_SEQUENCE);
@@ -151,6 +152,7 @@ public class SpecificTraceImpl extends TraceImpl<SequentialStep<? extends Specif
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Fsm_State_Step> getFsm_State_Step_Sequence() {
 		if (fsm_State_Step_Sequence == null) {
 			fsm_State_Step_Sequence = new EObjectResolvingEList<Fsm_State_Step>(Fsm_State_Step.class, this, FsmTracePackage.SPECIFIC_TRACE__FSM_STATE_STEP_SEQUENCE);
@@ -163,6 +165,7 @@ public class SpecificTraceImpl extends TraceImpl<SequentialStep<? extends Specif
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	@Override
 	public EList<Fsm_Transition_Fire> getFsm_Transition_Fire_Sequence() {
 		if (fsm_Transition_Fire_Sequence == null) {
 			fsm_Transition_Fire_Sequence = new EObjectResolvingEList<Fsm_Transition_Fire>(Fsm_Transition_Fire.class, this, FsmTracePackage.SPECIFIC_TRACE__FSM_TRANSITION_FIRE_SEQUENCE);

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/org/eclipse/gemoc/example/melangek3fsm/xsfsm/xsfsm/trace/tracemanager/FsmTraceConstructor.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/org/eclipse/gemoc/example/melangek3fsm/xsfsm/xsfsm/trace/tracemanager/FsmTraceConstructor.java
@@ -58,14 +58,14 @@ public class FsmTraceConstructor implements ITraceConstructor {
 	private boolean addNewObjectToState(org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.NamedElement o_cast,
 			fsmTrace.States.SpecificState newState) {
 		boolean added = false;
-		if (o_cast instanceof org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.StateMachine) {
+		if (o_cast instanceof org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.State) {
+			added = addNewObjectToState((org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.State) o_cast,
+					newState);
+		} else if (o_cast instanceof org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.StateMachine) {
 			added = addNewObjectToState((org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.StateMachine) o_cast,
 					newState);
 		} else if (o_cast instanceof org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.Transition) {
 			added = addNewObjectToState((org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.Transition) o_cast,
-					newState);
-		} else if (o_cast instanceof org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.State) {
-			added = addNewObjectToState((org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.State) o_cast,
 					newState);
 		}
 
@@ -206,29 +206,6 @@ public class FsmTraceConstructor implements ITraceConstructor {
 						org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.StateMachine o_cast = (org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.StateMachine) o;
 
 						if (p.getFeatureID() == org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.FsmPackage.eINSTANCE
-								.getStateMachine_UnprocessedString().getFeatureID()) {
-
-							// Rollback: we remove the last value of this field from the new state
-							fsmTrace.States.fsm.TracedStateMachine traced = (fsmTrace.States.fsm.TracedStateMachine) exeToTraced
-									.get(o);
-							fsmTrace.States.StateMachine_unprocessedString_Value lastValue = traced
-									.getStateMachine_unprocessedString_Dimension().getValues()
-									.get(traced.getStateMachine_unprocessedString_Dimension().getValues().size() - 1);
-							newState.getValues().remove(lastValue);
-
-							// And we create a proper new value
-							fsmTrace.States.StateMachine_unprocessedString_Value newValue = fsmTrace.States.StatesFactory.eINSTANCE
-									.createStateMachine_unprocessedString_Value();
-
-							java.lang.String value = o_cast.getUnprocessedString();
-
-							newValue.setUnprocessedString((java.lang.String) value);
-
-							traced.getStateMachine_unprocessedString_Dimension().getValues().add(newValue);
-							newState.getValues().add(newValue);
-						} else
-
-						if (p.getFeatureID() == org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.FsmPackage.eINSTANCE
 								.getStateMachine_ConsummedString().getFeatureID()) {
 
 							// Rollback: we remove the last value of this field from the new state
@@ -248,6 +225,29 @@ public class FsmTraceConstructor implements ITraceConstructor {
 							newValue.setConsummedString((java.lang.String) value);
 
 							traced.getStateMachine_consummedString_Dimension().getValues().add(newValue);
+							newState.getValues().add(newValue);
+						} else
+
+						if (p.getFeatureID() == org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.FsmPackage.eINSTANCE
+								.getStateMachine_ProducedString().getFeatureID()) {
+
+							// Rollback: we remove the last value of this field from the new state
+							fsmTrace.States.fsm.TracedStateMachine traced = (fsmTrace.States.fsm.TracedStateMachine) exeToTraced
+									.get(o);
+							fsmTrace.States.StateMachine_producedString_Value lastValue = traced
+									.getStateMachine_producedString_Dimension().getValues()
+									.get(traced.getStateMachine_producedString_Dimension().getValues().size() - 1);
+							newState.getValues().remove(lastValue);
+
+							// And we create a proper new value
+							fsmTrace.States.StateMachine_producedString_Value newValue = fsmTrace.States.StatesFactory.eINSTANCE
+									.createStateMachine_producedString_Value();
+
+							java.lang.String value = o_cast.getProducedString();
+
+							newValue.setProducedString((java.lang.String) value);
+
+							traced.getStateMachine_producedString_Dimension().getValues().add(newValue);
 							newState.getValues().add(newValue);
 						} else
 
@@ -279,25 +279,25 @@ public class FsmTraceConstructor implements ITraceConstructor {
 						} else
 
 						if (p.getFeatureID() == org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.fsm.FsmPackage.eINSTANCE
-								.getStateMachine_ProducedString().getFeatureID()) {
+								.getStateMachine_UnprocessedString().getFeatureID()) {
 
 							// Rollback: we remove the last value of this field from the new state
 							fsmTrace.States.fsm.TracedStateMachine traced = (fsmTrace.States.fsm.TracedStateMachine) exeToTraced
 									.get(o);
-							fsmTrace.States.StateMachine_producedString_Value lastValue = traced
-									.getStateMachine_producedString_Dimension().getValues()
-									.get(traced.getStateMachine_producedString_Dimension().getValues().size() - 1);
+							fsmTrace.States.StateMachine_unprocessedString_Value lastValue = traced
+									.getStateMachine_unprocessedString_Dimension().getValues()
+									.get(traced.getStateMachine_unprocessedString_Dimension().getValues().size() - 1);
 							newState.getValues().remove(lastValue);
 
 							// And we create a proper new value
-							fsmTrace.States.StateMachine_producedString_Value newValue = fsmTrace.States.StatesFactory.eINSTANCE
-									.createStateMachine_producedString_Value();
+							fsmTrace.States.StateMachine_unprocessedString_Value newValue = fsmTrace.States.StatesFactory.eINSTANCE
+									.createStateMachine_unprocessedString_Value();
 
-							java.lang.String value = o_cast.getProducedString();
+							java.lang.String value = o_cast.getUnprocessedString();
 
-							newValue.setProducedString((java.lang.String) value);
+							newValue.setUnprocessedString((java.lang.String) value);
 
-							traced.getStateMachine_producedString_Dimension().getValues().add(newValue);
+							traced.getStateMachine_unprocessedString_Dimension().getValues().add(newValue);
 							newState.getValues().add(newValue);
 						}
 					}

--- a/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/org/eclipse/gemoc/example/melangek3fsm/xsfsm/xsfsm/trace/tracemanager/FsmTraceStateManager.java
+++ b/official_samples/MelangeK3FSM/language_workbench/org.eclipse.gemoc.example.melangek3fsm.xsfsm.xsfsm.trace/src/org/eclipse/gemoc/example/melangek3fsm/xsfsm/xsfsm/trace/tracemanager/FsmTraceStateManager.java
@@ -57,7 +57,6 @@ public class FsmTraceStateManager implements IStateManager<State<?, ?>> {
 		return result;
 	}
 
-	@SuppressWarnings("unchecked")
 	private void restoreStateExecute(fsmTrace.States.SpecificState state) {
 		for (fsmTrace.States.SpecificValue value : state.getValues()) {
 			if (value instanceof fsmTrace.States.StateMachine_consummedString_Value) {


### PR DESCRIPTION
## Description

This update the studio dependencies to support the update of the mocc language so they can use the non-deprecatd xtext generator


## Changes

- use latest available version of timesquare   2023-07-26
- update MelangeFSM official example with latest trace generator 
- update documentation about using the gemoc_builder docker image
 
## Contribution to issues

Contribute to #  
Closes # 

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - https://github.com/eclipse/gemoc-studio-moccml/pull/29 
